### PR TITLE
Refine minimap display and fish distribution

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Reel 'Em All! – Prototype</title>
+  <title>Lure Casting – Prototype</title>
   <style>
     :root {
       --bg: #0b132b;
@@ -20,19 +20,26 @@
     }
 
     * { margin: 0; padding: 0; box-sizing: border-box; }
-    body { 
-      background: var(--bg); 
-      color: var(--text); 
+    body {
+      background: var(--bg);
+      color: var(--text);
       font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
       overflow: hidden;
-      height: 100vh;
+      min-height: 100vh;
+      display: flex;
+      justify-content: center;
+      align-items: stretch;
     }
 
     #game {
       position: relative;
-      width: 100vw;
+      width: min(420px, 100vw);
       height: 100vh;
       overflow: hidden;
+      margin: 0 auto;
+      box-shadow: 0 0 40px rgba(0, 0, 0, 0.45);
+      border-radius: 18px 18px 0 0;
+      background: #020817;
     }
 
     #view {
@@ -44,13 +51,14 @@
 
     .hud {
       position: absolute;
-      top: 20px;
+      top: clamp(96px, 20vh, 150px);
       width: 100%;
       display: flex;
       justify-content: space-between;
       padding: 0 20px;
       pointer-events: none;
-      z-index: 10;
+      z-index: 35;
+      transition: top 0.6s cubic-bezier(0.22, 1, 0.36, 1);
     }
 
     .pill {
@@ -63,137 +71,218 @@
       backdrop-filter: blur(10px);
     }
 
-    .center-title {
+    #titleBar {
       position: absolute;
-      top: 50%;
-      left: 50%;
-      transform: translate(-50%, -50%);
-      text-align: center;
-      z-index: 20;
-      color: var(--text);
+      top: 0;
+      left: 0;
+      width: 100%;
+      padding: 18px 24px 80px;
+      background: linear-gradient(135deg, rgba(91, 192, 190, 0.12), rgba(63, 81, 181, 0.28));
+      backdrop-filter: blur(14px);
+      border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+      display: flex;
+      justify-content: center;
+      z-index: 30;
+      overflow: visible;
+      transform: translateY(0);
+      transition: transform 0.6s cubic-bezier(0.22, 1, 0.36, 1), opacity 0.6s ease;
     }
 
-    .title {
-      font-size: 3rem;
+    #titleBar::after {
+      content: '';
+      position: absolute;
+      left: 0;
+      right: 0;
+      bottom: -90px;
+      height: 160px;
+      background: linear-gradient(180deg, rgba(15, 23, 42, 0.72), rgba(15, 23, 42, 0));
+      pointer-events: none;
+      z-index: -1;
+      transition: opacity 0.6s ease;
+    }
+
+    #titleBar h1 {
+      font-size: 2.1rem;
       font-weight: 800;
-      margin-bottom: 10px;
-      text-shadow: 2px 2px 4px rgba(0,0,0,0.8);
-      background: linear-gradient(45deg, var(--primary), var(--secondary));
-      -webkit-background-clip: text;
-      -webkit-text-fill-color: transparent;
-      background-clip: text;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: var(--text);
+      text-shadow: 0 4px 16px rgba(2, 8, 23, 0.8);
     }
 
-    .subtitle {
-      font-size: 1.2rem;
+    #mainMenu {
+      position: absolute;
+      top: 100px;
+      bottom: 120px;
+      left: 0;
+      width: 100%;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: flex-end;
+      gap: 20px;
+      padding: 0 30px 16vh;
+      text-align: center;
+      color: var(--text);
+      z-index: 25;
+      transition: transform 0.6s cubic-bezier(0.22, 1, 0.36, 1), opacity 0.4s ease;
+    }
+
+    #mainMenu p {
+      font-size: 1rem;
       color: var(--text-dim);
-      margin-bottom: 30px;
+      max-width: 320px;
+      line-height: 1.5;
     }
 
     .tap {
-      display: inline-block;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-width: 180px;
       background: linear-gradient(135deg, var(--primary), var(--accent));
       color: white;
-      padding: 15px 30px;
-      border-radius: 25px;
+      padding: 15px 36px;
+      border-radius: 26px;
       font-size: 1.1rem;
       font-weight: 600;
       cursor: pointer;
       transition: all 0.3s ease;
-      box-shadow: 0 4px 15px rgba(91, 192, 190, 0.3);
+      box-shadow: 0 6px 24px rgba(91, 192, 190, 0.35);
     }
 
     .tap:hover {
       transform: translateY(-2px);
-      box-shadow: 0 6px 20px rgba(91, 192, 190, 0.4);
+      box-shadow: 0 10px 30px rgba(91, 192, 190, 0.45);
     }
 
     .tap.disabled {
       opacity: 0.6;
       cursor: not-allowed;
       transform: none;
+      box-shadow: none;
     }
 
     .tap.error {
       background: linear-gradient(135deg, var(--error), #cc5252);
     }
 
-    .version-tag {
-      position: absolute;
-      bottom: 10px;
-      right: 10px;
-      font-size: 0.8rem;
-      color: var(--text-dim);
-      opacity: 0.6;
-    }
-
-    .gauge {
-      display: none;
+    .bottom-nav {
       position: absolute;
       bottom: 20px;
-      left: 50%;
-      transform: translateX(-50%);
-      z-index: 20;
+      left: 0;
+      width: 100%;
+      display: flex;
+      justify-content: space-between;
+      padding: 0 24px;
+      z-index: 25;
+      transition: transform 0.5s cubic-bezier(0.22, 1, 0.36, 1), opacity 0.4s ease;
     }
 
-    .panel {
-      background: rgba(0, 0, 0, 0.8);
-      padding: 20px;
-      border-radius: 15px;
-      text-align: center;
+    .nav-btn {
+      flex: 1;
+      margin: 0 8px;
+      padding: 12px 0;
+      border-radius: 18px;
+      border: 1px solid rgba(255, 255, 255, 0.12);
+      background: rgba(15, 23, 42, 0.72);
+      color: var(--text);
+      font-weight: 600;
+      letter-spacing: 0.02em;
+      cursor: pointer;
+      transition: all 0.25s ease;
       backdrop-filter: blur(10px);
-      border: 1px solid rgba(255, 255, 255, 0.1);
     }
 
-    .panel h3 {
-      margin-bottom: 15px;
-      color: var(--primary);
+    .nav-btn:hover {
+      background: rgba(91, 192, 190, 0.2);
+      border-color: rgba(111, 255, 233, 0.45);
     }
 
-    .bar {
-      position: relative;
-      width: 300px;
-      height: 20px;
-      background: var(--bg-light);
-      border-radius: 10px;
-      overflow: hidden;
-      margin: 10px 0;
+    .nav-btn:active {
+      transform: translateY(1px);
     }
 
-    .sweet {
+    #exitBtn {
       position: absolute;
+      bottom: 90px;
+      left: 24px;
+      padding: 10px 18px;
+      border-radius: 16px;
+      background: rgba(2, 8, 23, 0.85);
+      color: var(--text);
+      font-weight: 600;
+      letter-spacing: 0.04em;
+      border: 1px solid rgba(255, 255, 255, 0.12);
+      cursor: pointer;
+      z-index: 40;
+      opacity: 0;
+      pointer-events: none;
+      transform: translateY(16px);
+      transition: opacity 0.35s ease, transform 0.35s ease;
+    }
+
+    #exitBtn:hover {
+      border-color: rgba(111, 255, 233, 0.45);
+      background: rgba(15, 23, 42, 0.95);
+    }
+
+    .cast-prompt {
+      position: absolute;
+      top: 75%;
       left: 50%;
-      top: 0;
-      width: 60px;
-      height: 100%;
-      background: var(--error);
-      transform: translateX(-50%);
-      border-radius: 10px;
+      transform: translate(-50%, -50%);
+      background: rgba(0, 0, 0, 0.78);
+      padding: 16px 24px;
+      border-radius: 28px;
+      font-size: 1.1rem;
+      font-weight: 700;
+      color: var(--secondary);
+      letter-spacing: 0.04em;
+      text-align: center;
+      z-index: 35;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 0.3s ease;
+      max-width: 80%;
+      line-height: 1.4;
+      box-shadow: 0 10px 35px rgba(17, 24, 39, 0.55);
     }
 
-    .cursor {
-      position: absolute;
-      top: 0;
-      width: 5px;
-      height: 100%;
-      background: var(--secondary);
-      border-radius: 2px;
+    .cast-prompt.show {
+      opacity: 1;
     }
 
-    .hint {
-      font-size: 0.9rem;
-      color: var(--text-dim);
-      margin: 10px 0;
+    #game.gameplay #titleBar {
+      transform: translateY(-140%);
+      opacity: 0;
+      pointer-events: none;
     }
 
-    .tapto {
-      background: var(--primary);
-      color: white;
-      padding: 8px 16px;
-      border-radius: 15px;
-      display: inline-block;
-      font-size: 0.9rem;
-      margin-top: 10px;
+    #game.gameplay #titleBar::after {
+      opacity: 0;
+    }
+
+    #game.gameplay .hud {
+      top: 22px;
+    }
+
+    #game.gameplay #mainMenu {
+      opacity: 0;
+      transform: translateY(40px);
+      pointer-events: none;
+    }
+
+    #game.gameplay .bottom-nav {
+      opacity: 0;
+      transform: translateY(30px);
+      pointer-events: none;
+    }
+
+    #game.gameplay #exitBtn {
+      opacity: 1;
+      pointer-events: auto;
+      transform: translateY(0);
     }
 
     .toast {
@@ -250,41 +339,91 @@
     .minimap {
       display: none;
       position: absolute;
-      bottom: 20px;
-      right: 20px;
-      background: rgba(0, 0, 0, 0.8);
-      padding: 15px;
-      border-radius: 15px;
+      top: 160px;
+      bottom: 160px;
+      right: 6px;
+      width: 20px;
+      padding: 6px 4px;
+      border-radius: 16px;
+      background: rgba(4, 11, 23, 0.85);
+      border: 1px solid rgba(111, 255, 233, 0.16);
+      box-shadow: 0 0 14px rgba(0, 0, 0, 0.35);
       backdrop-filter: blur(10px);
-      border: 1px solid rgba(255, 255, 255, 0.1);
-      z-index: 15;
-    }
-
-    .minimap h4 {
-      font-size: 0.9rem;
-      margin-bottom: 10px;
-      color: var(--primary);
-      text-align: center;
+      z-index: 32;
+      justify-content: center;
+      align-items: center;
     }
 
     .mmbar {
       position: relative;
-      width: 120px;
-      height: 60px;
-      background: var(--bg-light);
-      border-radius: 8px;
+      width: 100%;
+      height: 100%;
+      border-radius: 14px;
       overflow: hidden;
+      background: linear-gradient(to top, rgba(15, 23, 42, 0.9), rgba(15, 23, 42, 0.75));
+      display: flex;
     }
 
-    .mmcenter {
+    .mmcells {
+      display: flex;
+      flex-direction: column;
+      width: 100%;
+      height: 100%;
+      gap: 0;
+    }
+
+    .mmcell {
+      flex: 1 1 0;
+      width: 100%;
+      transition: background-color 0.25s ease;
+    }
+
+    .mmviewport {
       position: absolute;
-      left: 50%;
-      top: 50%;
-      width: 4px;
-      height: 4px;
+      left: 2px;
+      right: 2px;
+      border-radius: 10px;
+      border: 1px solid rgba(111, 255, 233, 0.55);
+      box-shadow: 0 0 12px rgba(111, 255, 233, 0.35);
+      pointer-events: none;
+      opacity: 0;
+      transition: opacity 0.2s ease;
+    }
+
+    .mmbobber {
+      position: absolute;
+      left: 4px;
+      right: 4px;
+      height: 2px;
       background: var(--secondary);
-      transform: translate(-50%, -50%);
-      border-radius: 50%;
+      box-shadow: 0 0 10px rgba(111, 255, 233, 0.6);
+      border-radius: 2px;
+      pointer-events: none;
+      opacity: 0;
+      transition: opacity 0.2s ease;
+      transform: translateY(-50%);
+    }
+
+    .version-tag {
+      position: absolute;
+      bottom: 18px;
+      left: 50%;
+      transform: translateX(-50%);
+      padding: 6px 16px;
+      font-size: 0.82rem;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      background: rgba(9, 14, 31, 0.72);
+      border: 1px solid rgba(111, 255, 233, 0.18);
+      border-radius: 999px;
+      color: var(--secondary);
+      z-index: 28;
+      transition: opacity 0.35s ease;
+    }
+
+    #game.gameplay .version-tag {
+      opacity: 0;
+      pointer-events: none;
     }
 
     .modal {
@@ -306,7 +445,7 @@
       padding: 30px;
       border-radius: 20px;
       text-align: center;
-      max-width: 400px;
+      max-width: 420px;
       width: 90%;
       border: 1px solid rgba(255, 255, 255, 0.1);
     }
@@ -315,6 +454,30 @@
       color: var(--primary);
       margin-bottom: 20px;
       font-size: 1.5rem;
+    }
+
+    .catch-visual {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 12px;
+      margin: 12px 0 24px;
+    }
+
+    .catch-visual img {
+      max-width: 160px;
+      width: 70%;
+      height: auto;
+      filter: drop-shadow(0 12px 18px rgba(0, 0, 0, 0.35));
+    }
+
+    .catch-visual .placeholder {
+      width: 70%;
+      max-width: 150px;
+      aspect-ratio: 3 / 1;
+      border-radius: 16px;
+      background: rgba(12, 20, 34, 0.8);
+      border: 1px dashed rgba(148, 163, 184, 0.35);
     }
 
     .actions {
@@ -344,17 +507,22 @@
     }
 
     @media (max-width: 768px) {
-      .title { font-size: 2rem; }
-      .subtitle { font-size: 1rem; }
-      .bar { width: 250px; }
-      .hud { padding: 0 10px; }
+      body { align-items: flex-start; }
+      #game { border-radius: 0; box-shadow: none; }
+      #titleBar h1 { font-size: 1.6rem; }
+      #mainMenu { padding: 0 20px 18vh; }
+      .hud { padding: 0 12px; }
     }
   </style>
 </head>
 <body>
   <div id="game">
     <canvas id="view" aria-label="game view"></canvas>
-    
+
+    <header id="titleBar">
+      <h1>Lure Casting</h1>
+    </header>
+
     <div class="hud">
       <div class="left">
         <div class="pill">⚡ Energy: <span id="energy">10</span></div>
@@ -364,33 +532,31 @@
       </div>
     </div>
 
-    <div class="center-title" id="title">
-      <div class="title">Reel 'Em All!</div>
-      <div class="subtitle">릴럼올! – Touch to Start</div>
+    <div id="mainMenu">
+      <p>Take aim and send your lure upstream to tempt rare fish across the river.</p>
       <div class="tap" id="startBtn">Loading Assets...</div>
     </div>
 
-    <div class="version-tag" id="versionTag" aria-hidden="true">Version v0.5.0-improved</div>
-
-    <div class="gauge" id="gauge">
-      <div class="panel">
-        <h3>Cast Power</h3>
-        <div class="bar" id="bar">
-          <div class="sweet" id="sweet"></div>
-          <div class="cursor" id="cursor"></div>
-        </div>
-        <div class="hint">Stop the cursor in the <b style="color:#ff8b8b">red</b> zone. Closer to the center = farther cast.</div>
-        <div class="tap tapto">Tap / Click to Stop</div>
-      </div>
+    <div class="bottom-nav" id="navBar">
+      <button class="nav-btn" id="shopBtn" type="button">Shop</button>
+      <button class="nav-btn" id="rankBtn" type="button">Ranking</button>
+      <button class="nav-btn" id="premiumBtn" type="button">Premium Mode</button>
     </div>
+
+    <button id="exitBtn" type="button">Exit</button>
+
+    <div class="version-tag" id="versionTag" aria-hidden="true">v1.0.0</div>
 
     <div class="toast" id="toast"></div>
     <div class="miss-effect" id="missEffect">MISS!</div>
     <div class="distance" id="distance"></div>
 
-    <div class="minimap" id="minimap">
-      <h4>Mini‑map (Detection Range)</h4>
-      <div class="mmbar" id="mmbar"><div class="mmcenter"></div></div>
+    <div class="minimap" id="minimap" aria-hidden="true">
+      <div class="mmbar" id="mmbar">
+        <div class="mmcells" id="mmcells"></div>
+        <div class="mmviewport" id="mmviewport"></div>
+        <div class="mmbobber" id="mmbobber"></div>
+      </div>
     </div>
 
     <div class="modal" id="results">
@@ -403,1399 +569,17 @@
         </div>
       </div>
     </div>
+
+    <div class="cast-prompt" id="castPrompt">Press the Screen to cast the bobber</div>
   </div>
 
-  <script>
-    // === 유틸리티 함수들 ===
-    const clamp = (v, min, max) => Math.max(min, Math.min(max, v));
-    const lerp = (a, b, t) => a + (b - a) * t;
-    const rand = (min, max) => Math.random() * (max - min) + min;
-    const randi = (min, max) => Math.floor(rand(min, max + 1));
-    const pick = arr => arr[Math.floor(Math.random() * arr.length)];
+  
+  <script src="js/state.js"></script>
+  <script src="js/utils.js"></script>
+  <script src="js/fishAI.js"></script>
+  <script src="js/gameplay.js"></script>
+  <script src="js/rendering.js"></script>
+  <script src="js/main.js"></script>
 
-    function loadImage(src) {
-      return new Promise((resolve, reject) => {
-        const img = new Image();
-        img.crossOrigin = 'anonymous';
-        img.onload = () => resolve(img);
-        img.onerror = reject;
-        img.src = src;
-      });
-    }
-
-    function getCssVar(name) {
-      return getComputedStyle(document.documentElement).getPropertyValue(name).trim();
-    }
-
-    // === 상수 정의 ===
-    const GameState = {
-      Idle: 'Idle',
-      Casting: 'Casting', 
-      Flight: 'Flight',
-      Fishing: 'Fishing',
-      Results: 'Results'
-    };
-
-    const RARITY_WEIGHTS = {
-      Common: 100,
-      Uncommon: 50,
-      Rare: 20,
-      Epic: 8,
-      Legendary: 3,
-      Mythic: 1
-    };
-
-    const FISH_SWIM_SPEED_TABLE = {
-      Fast: 12,
-      Normal: 8,
-      Slow: 5
-    };
-
-    const DETECTION_RANGE_M = 5;
-
-    // === 게임 상태 변수들 ===
-    let canvas, ctx;
-    let state = GameState.Idle;
-    let globalTime = 0;
-    let dataLoaded = false;
-    let assetsReady = false;
-
-    // DOM 요소들
-    let startBtn, title, gauge, bar, sweet, cursor, toastEl, missEffect;
-    let distanceEl, minimap, mmbar, results, rTitle, rBody, rNext, rSkip;
-    let energyEl, pointsEl;
-
-    // 게임 데이터
-    const gameData = {
-      species: [],
-      resources: { fish: new Map() }
-    };
-
-    let SPECIES = [];
-
-    // 게임 세팅
-    const settings = {
-      energy: 10,
-      points: 0,
-      baseCast: 30,
-      maxCast: 200,
-      rodTier: 1,
-      lineTier: 1
-    };
-
-    // 월드 상태
-    const world = {
-      castDistance: 0,
-      bobberDist: 0,
-      fishes: [],
-      actives: [],
-      catches: [],
-      time: 0
-    };
-
-    // 카메라와 렌더링
-    const camera = { y: 0 };
-    const rodAnchor = { x: 0, y: 0 };
-    let baseX = 0;
-
-    // 환경 상태
-    const environmentState = {
-      tileWidth: 40,
-      tileHeight: 40, 
-      landRows: 3,
-      water: null,
-      shore: null,
-      land: null
-    };
-
-    // 캐릭터 스프라이트
-    const characterSprite = {
-      image: null,
-      frameWidth: 40,
-      frameHeight: 40,
-      frameCount: 4,
-      currentFrame: 0,
-      idleFrame: 0,
-      postCastFrame: 3,
-      castSequence: [0, 1, 2, 3],
-      frameDuration: 0.12,
-      scale: 2.4,
-      lineAnchor: { x: 30, y: 18 },
-      playing: false,
-      animationIndex: 0,
-      timer: 0,
-      holdFrame: 3
-    };
-
-    // === 물고기 데이터 ===
-    const fishData = {
-      species: [
-        {
-          id: "carp",
-          displayName: "Common Carp", 
-          rarity: "Common",
-          size_cm: {min: 35, max: 80},
-          weight_kg: {min: 1.0, max: 7.0},
-          basePoints: 60,
-          ui: {mapColorHex: "#8BC34A"},
-          behavior: {
-            swimSpeed: "Slow", 
-            approachBias: 0.55,
-            circleShrinkRate: 0.9
-          },
-          equipment: {recRodTier: 1, recLineTier: 1, breakRef_kg: 5},
-          scoring: {rarityMult: 1.0, weightExp: 1.2, sizeExp: 0.8, distanceBonusCap: 1.15}
-        },
-        {
-          id: "trout",
-          displayName: "River Trout",
-          rarity: "Uncommon", 
-          size_cm: {min: 25, max: 60},
-          weight_kg: {min: 0.5, max: 3.0},
-          basePoints: 85,
-          ui: {mapColorHex: "#00BCD4"},
-          behavior: {
-            swimSpeed: "Fast", 
-            approachBias: 0.45,
-            circleShrinkRate: 1.1
-          },
-          equipment: {recRodTier: 1, recLineTier: 1, breakRef_kg: 3.5},
-          scoring: {rarityMult: 1.15, weightExp: 1.25, sizeExp: 0.9, distanceBonusCap: 1.18}
-        },
-        {
-          id: "pike",
-          displayName: "Northern Pike",
-          rarity: "Rare",
-          size_cm: {min: 50, max: 120},
-          weight_kg: {min: 2.0, max: 14.0},
-          basePoints: 160,
-          ui: {mapColorHex: "#4CAF50"},
-          behavior: {
-            swimSpeed: "Fast", 
-            approachBias: 0.4,
-            circleShrinkRate: 1.2
-          },
-          equipment: {recRodTier: 2, recLineTier: 2, breakRef_kg: 8},
-          scoring: {rarityMult: 1.35, weightExp: 1.35, sizeExp: 1.0, distanceBonusCap: 1.2}
-        },
-        {
-          id: "salmon",
-          displayName: "Coho Salmon",
-          rarity: "Rare",
-          size_cm: {min: 55, max: 90},
-          weight_kg: {min: 2.0, max: 8.0},
-          basePoints: 170,
-          ui: {mapColorHex: "#F44336"},
-          behavior: {
-            swimSpeed: "Fast", 
-            approachBias: 0.42,
-            circleShrinkRate: 1.15
-          },
-          equipment: {recRodTier: 2, recLineTier: 2, breakRef_kg: 6.5},
-          scoring: {rarityMult: 1.35, weightExp: 1.35, sizeExp: 1.0, distanceBonusCap: 1.2}
-        },
-        {
-          id: "koi_golden",
-          displayName: "Golden Koi",
-          rarity: "Epic",
-          size_cm: {min: 35, max: 75},
-          weight_kg: {min: 1.0, max: 6.0},
-          basePoints: 240,
-          ui: {mapColorHex: "#FFC107"},
-          behavior: {
-            swimSpeed: "Slow", 
-            approachBias: 0.35,
-            circleShrinkRate: 1.0
-          },
-          equipment: {recRodTier: 2, recLineTier: 2, breakRef_kg: 6},
-          scoring: {rarityMult: 1.6, weightExp: 1.3, sizeExp: 1.1, distanceBonusCap: 1.18}
-        },
-        {
-          id: "sturgeon",
-          displayName: "River Sturgeon",
-          rarity: "Legendary",
-          size_cm: {min: 80, max: 180},
-          weight_kg: {min: 6.0, max: 40.0},
-          basePoints: 420,
-          ui: {mapColorHex: "#607D8B"},
-          behavior: {
-            swimSpeed: "Normal", 
-            approachBias: 0.3,
-            circleShrinkRate: 1.25
-          },
-          equipment: {recRodTier: 3, recLineTier: 3, breakRef_kg: 18},
-          scoring: {rarityMult: 2.1, weightExp: 1.45, sizeExp: 1.1, distanceBonusCap: 1.2}
-        }
-      ]
-    };
-
-    // === 에셋 로딩 시스템 ===
-    async function loadGameAssets() {
-      try {
-        // 기본 데이터 설정
-        gameData.species = fishData.species;
-        SPECIES = gameData.species;
-        
-        const assetTasks = [];
-        
-        // 환경 에셋들 - 실제 파일 경로로 시도, 실패시 폴백
-        const environmentAssets = [
-          { key: 'water', paths: ['assets/characters/river.png', 'data/river.png', './river.png'] },
-          { key: 'shore', paths: ['assets/characters/land01.png', 'data/land01.png', './land01.png'] },  
-          { key: 'land', paths: ['assets/characters/land02.png', 'data/land02.png', './land02.png'] }
-        ];
-        
-        for (const asset of environmentAssets) {
-          assetTasks.push(
-            loadImageWithFallback(asset.paths).then(img => {
-              if (img) {
-                environmentState[asset.key] = img;
-                if (asset.key === 'shore') {
-                  environmentState.tileWidth = img.width;
-                  environmentState.tileHeight = img.height;
-                }
-                console.log(`✓ Loaded ${asset.key}`);
-              }
-            }).catch(err => {
-              console.warn(`Failed to load ${asset.key}, using fallback`);
-            })
-          );
-        }
-        
-        // 캐릭터 스프라이트
-        assetTasks.push(
-          loadImageWithFallback(['assets/characters/char.png', 'data/char.png', './char.png']).then(img => {
-            if (img) {
-              characterSprite.image = img;
-              console.log('✓ Loaded character sprite');
-            }
-          }).catch(err => {
-            console.warn('Failed to load character sprite, using fallback');
-          })
-        );
-        
-        // 물고기 에셋들
-        const fishAssetMap = {
-          'carp': ['assets/fish/carp.png', 'data/carp.png', './carp.png'],
-          'trout': ['assets/fish/trout.png', 'data/trout.png', './trout.png'], 
-          'pike': ['assets/fish/pike.png', 'data/pike.png', './pike.png'],
-          'salmon': ['assets/fish/salmon.png', 'data/salmon.png', './salmon.png'],
-          'koi_golden': ['assets/fish/koi_golden.png', 'data/koi_golden.png', './koi_golden.png'],
-          'sturgeon': ['assets/fish/sturgeon.png', 'data/sturgeon.png', './sturgeon.png']
-        };
-        
-        for (const [speciesId, paths] of Object.entries(fishAssetMap)) {
-          assetTasks.push(
-            loadImageWithFallback(paths).then(img => {
-              if (img) {
-                gameData.resources.fish.set(speciesId, img);
-                console.log(`✓ Loaded fish: ${speciesId}`);
-              }
-            }).catch(err => {
-              console.warn(`Failed to load fish ${speciesId}, using fallback`);
-            })
-          );
-        }
-        
-        // 모든 에셋 로딩 완료 대기
-        await Promise.all(assetTasks);
-        
-        dataLoaded = true;
-        assetsReady = true;
-        
-        // 로딩된 에셋 개수 보고
-        const loadedFish = gameData.resources.fish.size;
-        const loadedEnv = [environmentState.water, environmentState.shore, environmentState.land].filter(x => x).length;
-        console.log(`Assets loaded - Fish: ${loadedFish}/6, Environment: ${loadedEnv}/3, Character: ${characterSprite.image ? 1 : 0}/1`);
-        
-        return true;
-        
-      } catch (err) {
-        console.error('Failed to load game assets:', err);
-        // 에셋 로딩 실패해도 게임은 계속 진행 (폴백 그래픽 사용)
-        dataLoaded = true;
-        assetsReady = true;
-        return true;
-      }
-    }
-
-    // 여러 경로로 이미지 로딩 시도
-    function loadImageWithFallback(paths) {
-      return new Promise((resolve, reject) => {
-        let attemptIndex = 0;
-        
-        function tryNext() {
-          if (attemptIndex >= paths.length) {
-            resolve(null); // 모든 경로 실패시 null 반환 (폴백 사용)
-            return;
-          }
-          
-          const img = new Image();
-          img.crossOrigin = 'anonymous';
-          img.onload = () => resolve(img);
-          img.onerror = () => {
-            attemptIndex++;
-            tryNext();
-          };
-          img.src = paths[attemptIndex];
-        }
-        
-        tryNext();
-      });
-    }
-
-    // === 물고기 AI 시스템 ===
-    function getFishMoveBias(spec) {
-      const tag = spec?.behavior?.swimSpeed || 'Normal';
-      if (tag === 'Fast') return 0.7;
-      if (tag === 'Slow') return 0.4;
-      return 0.55;
-    }
-
-    function getFishSwimSpeed(spec, weightKg) {
-      const tag = spec?.behavior?.swimSpeed || 'Normal';
-      const base = FISH_SWIM_SPEED_TABLE[tag] ?? FISH_SWIM_SPEED_TABLE.Normal;
-      const range = (spec?.weight_kg?.max ?? 0) - (spec?.weight_kg?.min ?? 0);
-      const minW = spec?.weight_kg?.min ?? weightKg;
-      const norm = range > 0 ? clamp((weightKg - minW) / range, 0, 1) : 0.5;
-      const heavinessAdjust = lerp(1.15, 0.85, norm);
-      return base * heavinessAdjust;
-    }
-
-    function updateFishSimulation(dt) {
-      if (!world.fishes || !world.fishes.length) return;
-      
-      const bobberPos = { x: 0, y: world.bobberDist };
-      
-      for (const fish of world.fishes) {
-        if (!fish || fish.finished) continue;
-        
-        // 필수 속성 초기화
-        if (!fish.position) fish.position = { x: rand(-26, 26), y: fish.distance ?? 30 };
-        if (!fish.velocity) fish.velocity = { x: 0, y: 0 };
-        if (!fish.targetVelocity) fish.targetVelocity = { x: 0, y: 0 };
-        if (typeof fish.stressLevel !== 'number') fish.stressLevel = 0;
-        if (typeof fish.personalityFactor !== 'number') fish.personalityFactor = rand(0.8, 1.2);
-        if (typeof fish.escapeTimer !== 'number') fish.escapeTimer = 0;
-        
-        fish.escapeTimer = Math.max(0, fish.escapeTimer - dt);
-        
-        // 찌와의 거리 계산
-        const dx = fish.position.x - bobberPos.x;
-        const dy = fish.position.y - bobberPos.y;
-        const distToBobber = Math.sqrt(dx * dx + dy * dy);
-        
-        // 스트레스 계산
-        if (distToBobber < 8) {
-          fish.stressLevel = Math.min(1.0, fish.stressLevel + dt * 0.3);
-        } else {
-          fish.stressLevel = Math.max(0, fish.stressLevel - dt * 0.1);
-        }
-
-        // AI 기반 움직임 (2% 확률로 업데이트)
-        if (Math.random() < 0.02) {
-          const wanderAngle = globalTime * 0.5 + fish.specId.charCodeAt(0) * 0.1;
-          const wanderRadius = 0.3;
-          
-          let finalX = Math.cos(wanderAngle) * wanderRadius;
-          let finalY = Math.sin(wanderAngle) * wanderRadius * 0.7;
-          
-          // 회피 행동
-          if (distToBobber < 8) {
-            const force = (8 - distToBobber) / 8;
-            const normalizedX = dx / (distToBobber + 0.1);
-            const normalizedY = dy / (distToBobber + 0.1);
-            finalX += normalizedX * force * 2.5;
-            finalY += normalizedY * force * 2.5;
-          }
-          
-          const magnitude = Math.sqrt(finalX * finalX + finalY * finalY);
-          if (magnitude > 0.1) {
-            const speed = (fish.swimSpeed || 8) * fish.personalityFactor;
-            fish.targetVelocity.x = (finalX / magnitude) * speed;
-            fish.targetVelocity.y = (finalY / magnitude) * speed * 0.7;
-            fish.moving = true;
-          } else if (Math.random() > (fish.moveBias || 0.5)) {
-            fish.targetVelocity.x = 0;
-            fish.targetVelocity.y = 0;
-            fish.moving = false;
-          }
-        }
-        
-        // 속도 스무딩
-        const velocitySmooth = 1 - Math.pow(0.001, dt * 9);
-        fish.velocity.x += (fish.targetVelocity.x - fish.velocity.x) * velocitySmooth;
-        fish.velocity.y += (fish.targetVelocity.y - fish.velocity.y) * velocitySmooth;
-        
-        // 위치 업데이트
-        fish.position.x += fish.velocity.x * dt;
-        fish.position.y += fish.velocity.y * dt;
-        
-        // 경계 처리
-        let clamped = false;
-        if (fish.position.y < 30) { fish.position.y = 30; clamped = true; }
-        if (fish.position.y > 200) { fish.position.y = 200; clamped = true; }
-        if (fish.position.x < -52) { fish.position.x = -52; clamped = true; }
-        if (fish.position.x > 52) { fish.position.x = 52; clamped = true; }
-        
-        if (clamped) {
-          fish.targetVelocity.x *= -0.3;
-          fish.targetVelocity.y *= -0.3;
-        }
-        
-        // 거의 정지한 경우 완전 정지
-        const speedSq = fish.velocity.x * fish.velocity.x + fish.velocity.y * fish.velocity.y;
-        if (speedSq < 0.01 && !fish.moving) {
-          fish.velocity.x = 0;
-          fish.velocity.y = 0;
-        }
-        
-        fish.distance = fish.position.y;
-      }
-    }
-
-    // === 렌더링 시스템 ===
-    function getEnvironmentMetrics(W, H) {
-      const tileW = Math.max(1, Math.round(environmentState.tileWidth || 40));
-      const tileH = Math.max(1, Math.round(environmentState.tileHeight || 40));
-      const configuredStrips = Math.max(1, Math.floor(environmentState.landRows || 3));
-      const desiredLand = tileH * configuredStrips;
-      const minLand = tileH * 2;
-      const minWater = Math.max(tileH * 3, 160);
-      const landHeight = Math.min(Math.max(minLand, desiredLand), Math.max(minLand, H - minWater));
-      const shorelineY = Math.max(0, H - landHeight);
-      
-      let waterSurfaceY = shorelineY - Math.min(tileH * 0.6, 48);
-      waterSurfaceY = Math.min(waterSurfaceY, shorelineY - 4);
-      waterSurfaceY = Math.max(20, waterSurfaceY);
-      if (shorelineY < 24) waterSurfaceY = Math.max(4, shorelineY * 0.6);
-
-      const topMargin = Math.max(tileH * 1.5, Math.min(shorelineY * 0.45, 160));
-      const targetBobberY = Math.min(shorelineY - tileH * 1.4, Math.max(topMargin + tileH * 2, H * 0.35));
-      const available = Math.max(tileH * 2, shorelineY - topMargin);
-      const minScrollRange = H * 3;
-      let pxPerMeter = available / Math.max(1, settings.maxCast);
-      if (pxPerMeter * settings.maxCast < minScrollRange) pxPerMeter = minScrollRange / Math.max(1, settings.maxCast);
-      
-      const distancePxRange = pxPerMeter * settings.maxCast;
-      const minBaseY = waterSurfaceY - distancePxRange;
-      const maxScroll = Math.max(0, targetBobberY - minBaseY);
-      const bobberOffsetX = Math.max(4, (characterSprite.scale || 2) * 1.2);
-
-      return {
-        tileW, tileH, landHeight, shorelineY, waterSurfaceY, topMargin, targetBobberY,
-        pxPerMeter, distancePxRange, maxScroll, bobberOffsetX
-      };
-    }
-
-    function drawEnvironment(W, H, metrics, cameraY) {
-      ctx.fillStyle = getCssVar('--bg');
-      ctx.fillRect(0, 0, W, H);
-
-      const tileW = Math.max(1, Math.round(metrics.tileW));
-      const tileH = Math.max(1, Math.round(metrics.tileH));
-      const shorelineY = metrics.shorelineY;
-      const firstWaterY = Math.floor((-cameraY - tileH * 2) / tileH) * tileH;
-
-      // 물 그리기
-      for (let worldY = firstWaterY; worldY < shorelineY; worldY += tileH) {
-        const screenY = worldY + cameraY;
-        if (screenY > H) break;
-        drawWaterRow(screenY, tileW, tileH, W);
-      }
-
-      // 육지 그리기
-      const landLayers = Math.max(1, Math.ceil(metrics.landHeight / tileH));
-      let worldY = shorelineY;
-      for (let layer = 0; layer < landLayers + 2; layer++) {
-        const screenY = worldY + cameraY;
-        drawLandRow(screenY, tileW, tileH, W, layer === 0);
-        worldY += tileH;
-        if (screenY > H + tileH) break;
-      }
-    }
-
-    function drawWaterRow(y, tileW, tileH, width) {
-      if (environmentState.water) {
-        const tilesNeeded = Math.ceil(width / tileW) + 2;
-        const startX = -tileW;
-        for (let i = 0; i < tilesNeeded; i++) {
-          const x = startX + i * tileW;
-          ctx.drawImage(environmentState.water, x, y, tileW, tileH);
-        }
-      } else {
-        // 향상된 폴백: 더 사실적인 물 그래픽
-        const time = globalTime * 0.5;
-        const wave1 = Math.sin(time + y * 0.01) * 0.1;
-        const wave2 = Math.cos(time * 1.3 + y * 0.008) * 0.05;
-        const waveOffset = (wave1 + wave2) * 10;
-        
-        const grd = ctx.createLinearGradient(0, y + waveOffset, 0, y + tileH + waveOffset);
-        grd.addColorStop(0, '#1e40af');
-        grd.addColorStop(0.3, '#1d4ed8');
-        grd.addColorStop(0.7, '#2563eb');
-        grd.addColorStop(1, '#1e3a8a');
-        ctx.fillStyle = grd;
-        ctx.fillRect(0, y, width, tileH);
-        
-        // 물결 효과 추가
-        ctx.fillStyle = 'rgba(59, 130, 246, 0.3)';
-        const waveY = y + tileH * 0.3 + Math.sin(time * 2 + y * 0.02) * 5;
-        ctx.fillRect(0, waveY, width, 2);
-      }
-    }
-
-    function drawLandRow(y, tileW, tileH, width, shoreline) {
-      const img = shoreline ? environmentState.shore : (environmentState.land || environmentState.shore);
-      if (img) {
-        const tilesNeeded = Math.ceil(width / tileW) + 2;
-        const startX = -tileW;
-        for (let i = 0; i < tilesNeeded; i++) {
-          const x = startX + i * tileW;
-          ctx.drawImage(img, x, y, tileW, tileH);
-        }
-      } else {
-        // 향상된 폴백: 더 사실적인 땅 그래픽
-        if (shoreline) {
-          // 해안선
-          const grd = ctx.createLinearGradient(0, y, 0, y + tileH);
-          grd.addColorStop(0, '#8b7355');
-          grd.addColorStop(0.5, '#6d5a47');
-          grd.addColorStop(1, '#5a4a3a');
-          ctx.fillStyle = grd;
-          ctx.fillRect(0, y, width, tileH);
-          
-          // 모래/자갈 텍스처 효과
-          ctx.fillStyle = 'rgba(139, 115, 85, 0.3)';
-          for (let i = 0; i < width; i += 8) {
-            if (Math.random() > 0.7) {
-              ctx.fillRect(i, y + Math.random() * tileH, 2, 2);
-            }
-          }
-        } else {
-          // 일반 땅
-          const grd = ctx.createLinearGradient(0, y, 0, y + tileH);
-          grd.addColorStop(0, '#4a5d3a');
-          grd.addColorStop(0.5, '#3d4f2f');
-          grd.addColorStop(1, '#2f3d23');
-          ctx.fillStyle = grd;
-          ctx.fillRect(0, y, width, tileH);
-          
-          // 풀밭 효과
-          ctx.fillStyle = 'rgba(74, 93, 58, 0.4)';
-          for (let i = 0; i < width; i += 12) {
-            if (Math.random() > 0.6) {
-              ctx.fillRect(i, y + tileH * 0.1, 1, tileH * 0.3);
-            }
-          }
-        }
-      }
-    }
-
-    function updateCharacterAnimation(dt) {
-      const sprite = characterSprite;
-      if (!sprite) return;
-
-      const sequence = Array.isArray(sprite.castSequence) ? sprite.castSequence : [];
-      const frameDuration = typeof sprite.frameDuration === 'number' && sprite.frameDuration > 0 
-        ? sprite.frameDuration : 0.1;
-
-      if (sprite.playing && sequence.length) {
-        sprite.timer += dt;
-        if (sprite.timer >= frameDuration) {
-          sprite.timer -= frameDuration;
-          sprite.animationIndex++;
-          if (sprite.animationIndex >= sequence.length) {
-            sprite.playing = false;
-            const hold = sprite.holdFrame ?? sprite.postCastFrame;
-            if (typeof hold === 'number') sprite.currentFrame = hold;
-          } else {
-            const next = sequence[sprite.animationIndex];
-            if (typeof next === 'number') sprite.currentFrame = next;
-          }
-        }
-      } else if (state === GameState.Idle || state === GameState.Casting) {
-        sprite.currentFrame = sprite.idleFrame || 0;
-      }
-    }
-
-    function drawCharacterSprite(W, H, metrics, cameraY) {
-      const sprite = characterSprite;
-      const scale = sprite.scale || 2;
-      const frameW = sprite.frameWidth;
-      const frameH = sprite.frameHeight;
-      const destW = frameW * scale;
-      const destH = frameH * scale;
-      const charBaseX = W * 0.5 - destW * 0.5;
-      baseX = charBaseX;
-      const baseY = metrics.shorelineY + metrics.tileH * 0.2 - destH;
-      const drawY = baseY + cameraY;
-
-      if (sprite.image) {
-        const index = Math.max(0, Math.min(sprite.frameCount - 1, Math.floor(sprite.currentFrame)));
-        const sx = index * frameW;
-        ctx.drawImage(sprite.image, sx, 0, frameW, frameH, charBaseX, drawY, destW, destH);
-      } else {
-        // 향상된 폴백 캐릭터
-        // 몸통
-        const bodyColor = '#2dd4bf';
-        const shirtColor = '#1d4ed8';
-        const skinColor = '#f4a261';
-        
-        // 머리
-        ctx.fillStyle = skinColor;
-        ctx.beginPath();
-        ctx.arc(charBaseX + destW/2, drawY + 25, 18, 0, Math.PI * 2);
-        ctx.fill();
-        
-        // 몸통
-        ctx.fillStyle = shirtColor;
-        ctx.fillRect(charBaseX + destW/2 - 22, drawY + 35, 44, 50);
-        
-        // 팔 (낚싯대를 든 자세)
-        ctx.fillStyle = skinColor;
-        if (sprite.currentFrame >= 2) {
-          // 캐스팅 자세
-          ctx.fillRect(charBaseX + destW/2 + 15, drawY + 40, 15, 8);
-          ctx.fillRect(charBaseX + destW/2 - 30, drawY + 35, 15, 8);
-        } else {
-          // 기본 자세  
-          ctx.fillRect(charBaseX + destW/2 + 20, drawY + 45, 12, 25);
-          ctx.fillRect(charBaseX + destW/2 - 32, drawY + 45, 12, 25);
-        }
-        
-        // 다리
-        ctx.fillStyle = '#1e293b';
-        ctx.fillRect(charBaseX + destW/2 - 18, drawY + 85, 14, 30);
-        ctx.fillRect(charBaseX + destW/2 + 4, drawY + 85, 14, 30);
-        
-        // 낚싯대
-        ctx.strokeStyle = '#8b5a3c';
-        ctx.lineWidth = 3;
-        ctx.beginPath();
-        if (sprite.currentFrame >= 2) {
-          // 캐스팅 자세의 낚싯대
-          ctx.moveTo(charBaseX + destW/2 + 20, drawY + 45);
-          ctx.lineTo(charBaseX + destW/2 + 40, drawY + 20);
-        } else {
-          // 기본 자세의 낚싯대
-          ctx.moveTo(charBaseX + destW/2 + 25, drawY + 50);
-          ctx.lineTo(charBaseX + destW/2 + 45, drawY + 25);
-        }
-        ctx.stroke();
-      }
-
-      const anchor = sprite.lineAnchor || { x: frameW - 6, y: frameH * 0.5 };
-      const spriteScale = sprite.scale || scale;
-      rodAnchor.x = baseX + anchor.x * spriteScale;
-      rodAnchor.y = drawY + anchor.y * spriteScale;
-    }
-
-    function drawFishingLine(ax, ay, bx, by) {
-      ctx.strokeStyle = '#e5e7eb';
-      ctx.lineWidth = 2;
-      ctx.beginPath();
-      const sway = Math.sin(globalTime * 2.1) * 8;
-      const ctrlX = ax + sway;
-      const ctrlY = Math.min(ay - Math.max(60, Math.abs(by - ay) * 0.6), by - 18);
-      ctx.moveTo(ax, ay);
-      ctx.quadraticCurveTo(ctrlX, ctrlY, bx, by - 6);
-      ctx.stroke();
-    }
-
-    function drawBobber(x, y) {
-      ctx.fillStyle = '#ef4444';
-      ctx.beginPath(); 
-      ctx.arc(x, y, 7, 0, Math.PI * 2); 
-      ctx.fill();
-      ctx.fillStyle = '#ffffff';
-      ctx.beginPath(); 
-      ctx.arc(x, y - 2, 3, 0, Math.PI * 2); 
-      ctx.fill();
-    }
-
-    function updateCamera(distance, metrics, dt, state) {
-      const distancePx = clamp(distance * metrics.pxPerMeter, 0, metrics.distancePxRange);
-      const baseY = metrics.waterSurfaceY - distancePx;
-      let desired = 0;
-      if (state === GameState.Flight || state === GameState.Fishing) {
-        desired = clamp(metrics.targetBobberY - baseY, 0, metrics.maxScroll);
-      }
-      const smoothing = 1 - Math.pow(0.001, dt * 9);
-      camera.y += (desired - camera.y) * smoothing;
-      camera.y = clamp(camera.y, 0, metrics.maxScroll);
-      return { distancePx, baseY };
-    }
-
-    // === 게임플레이 로직 ===
-    function sampleSpecies() {
-      if (!SPECIES.length) return null;
-      const pool = [];
-      for (const s of SPECIES) {
-        const w = RARITY_WEIGHTS[s.rarity] || 1;
-        for (let i = 0; i < w; i++) pool.push(s);
-      }
-      if (!pool.length) return null;
-      return pick(pool);
-    }
-
-    function spawnFishes(dist, metrics, viewportWidth) {
-      if (!SPECIES.length) return { fishes: [], lateralLimit: 26, displayRange: 26 };
-      
-      const ratio = clamp(dist / settings.maxCast, 0.2, 1);
-      const count = randi(4 + ratio * 2, 6 + ratio * 3);
-      const fishes = [];
-      
-      for (let i = 0; i < count; i++) {
-        const spec = sampleSpecies();
-        if (!spec) continue;
-        
-        const size = rand(spec.size_cm.min, spec.size_cm.max);
-        const weight = rand(spec.weight_kg.min, spec.weight_kg.max);
-        const distance = rand(30, Math.min(dist + 20, 200));
-        const lateral = rand(-26, 26);
-        
-        const fish = {
-          specId: spec.id, spec, distance, size_cm: size, weight_kg: weight, engaged: false, finished: false,
-          iconColor: spec.ui.mapColorHex, position: { x: lateral, y: distance },
-          velocity: { x: 0, y: 0 }, targetVelocity: { x: 0, y: 0 }, bonusMultiplier: 1,
-          escapeTimer: 0, lastCircleTime: -Infinity, renderCache: null, image: null, active: null,
-          stressLevel: 0, personalityFactor: rand(0.8, 1.2), moveBias: getFishMoveBias(spec),
-          swimSpeed: getFishSwimSpeed(spec, weight)
-        };
-        fishes.push(fish);
-      }
-      
-      if (fishes.length) {
-        const pool = fishes.slice();
-        const special = pool.splice(Math.floor(Math.random() * pool.length), 1)[0];
-        if (special) special.bonusMultiplier = 2;
-        if (pool.length && Math.random() < 0.25) {
-          const rare = pool.splice(Math.floor(Math.random() * pool.length), 1)[0];
-          if (rare) rare.bonusMultiplier = 3;
-        }
-      }
-      
-      fishes.sort((a, b) => a.distance - b.distance);
-      return { fishes, lateralLimit: 52, displayRange: 26 };
-    }
-
-    function rollCatch(active) {
-      const f = active.fish;
-      const spec = f.spec;
-      const r = clamp((active.radius - active.minR) / (active.maxR - active.minR), 0, 1);
-      const skill = 1 - r;
-      
-      let p = 0.15 + 0.75 * skill;
-      p *= (0.8 + 0.5 * spec.behavior.approachBias);
-      
-      const stressPenalty = 1 - (f.stressLevel * 0.2);
-      p *= stressPenalty;
-      p = clamp(p, 0.05, 0.98);
-      
-      const difficultyMultiplier = {
-        Common: 1.15,
-        Uncommon: 1.05,
-        Rare: 0.95,
-        Epic: 0.85,
-        Legendary: 0.75,
-        Mythic: 0.65
-      }[spec.rarity] || 1;
-      
-      p *= difficultyMultiplier;
-      return Math.random() < p;
-    }
-
-    function computePoints(fish, castDistance) {
-      const s = fish.spec;
-      const sc = s.scoring;
-      const wNorm = (fish.weight_kg - s.weight_kg.min) / (s.weight_kg.max - s.weight_kg.min);
-      const szNorm = (fish.size_cm - s.size_cm.min) / (s.size_cm.max - s.size_cm.min);
-      const distanceFactor = clamp(1.0 + 0.20 * (castDistance - settings.baseCast) / (settings.maxCast - settings.baseCast), 1.0, sc.distanceBonusCap || 1.20);
-      const baseScore = s.basePoints * sc.rarityMult * Math.pow(1 + clamp(wNorm,0,1), sc.weightExp) * Math.pow(1 + clamp(szNorm,0,1), sc.sizeExp) * distanceFactor;
-      const multiplier = Math.max(1, fish?.bonusMultiplier || 1);
-      return Math.round(baseScore * multiplier);
-    }
-
-    function releaseActiveCircle(active, applyRetreat = true) {
-      if (!active) return;
-      const fish = active.fish;
-      if (fish) {
-        if (fish.active === active) fish.active = null;
-        fish.engaged = false;
-        if (!fish.finished && applyRetreat) {
-          const posY = fish.position?.y ?? fish.distance ?? 0;
-          const posX = fish.position?.x ?? 0;
-          const escape = Math.atan2(posY - world.bobberDist, posX) + Math.PI + rand(-0.45, 0.45);
-          const speed = (fish.swimSpeed || 10) * rand(1.2, 1.6) * fish.personalityFactor;
-          if (fish.targetVelocity) {
-            fish.targetVelocity.x = Math.cos(escape) * speed;
-            fish.targetVelocity.y = Math.sin(escape) * speed * 0.7;
-          }
-          fish.escapeTimer = rand(1.0, 2.0);
-          fish.stressLevel = Math.min(1.0, fish.stressLevel + 0.3);
-        }
-      }
-      active.life = 0;
-    }
-
-    function updateActiveCircles(dt, bx, by, metrics, cameraY) {
-      const pxPerMeter = metrics?.pxPerMeter || (canvas.clientHeight / Math.max(1, settings.maxCast));
-      const baseLife = 1.8;
-
-      for (const fish of world.fishes) {
-        if (!fish || fish.finished) continue;
-
-        const centerY = fish.position?.y ?? fish.distance;
-        const centerX = fish.position?.x ?? 0;
-        const range = DETECTION_RANGE_M;
-        
-        const dy = centerY - world.bobberDist;
-        const dx = centerX;
-        const distToBobber = Math.sqrt(dx * dx + dy * dy);
-
-        if (distToBobber <= range) {
-          if (!fish.active) {
-            const maxR = Math.max(24, range * pxPerMeter * 0.4);
-            const minR = Math.max(12, maxR * 0.35);
-            const shrinkRate = 15 + 20 * (fish.spec?.behavior?.circleShrinkRate ?? 1);
-            const active = { fish, radius: maxR, maxR, minR, life: baseLife, range, shrinkRate, detectionRange: range };
-            fish.engaged = true;
-            fish.lastCircleTime = globalTime;
-            fish.active = active;
-            world.actives.push(active);
-          }
-        } else if (fish.active && distToBobber > range * 1.2) {
-          fish.active.life = Math.min(fish.active.life, 0);
-        } else if (!fish.active) {
-          fish.engaged = false;
-        }
-      }
-
-      const kept = [];
-      for (const active of world.actives) {
-        const fish = active.fish;
-        if (!fish || fish.finished) {
-          releaseActiveCircle(active, false);
-          continue;
-        }
-
-        const centerY = fish.position?.y ?? fish.distance;
-        const centerX = fish.position?.x ?? 0;
-        const dy = centerY - world.bobberDist;
-        const dx = centerX;
-        const distToBobber = Math.sqrt(dx * dx + dy * dy);
-
-        if (distToBobber > active.detectionRange * 1.3) {
-          releaseActiveCircle(active, true);
-          continue;
-        }
-
-        const proximityFactor = active.detectionRange > 0 ? clamp(1 - distToBobber / active.detectionRange, 0, 1) : 1;
-        const targetRadius = lerp(active.maxR, active.minR, proximityFactor * 0.7);
-        
-        const blend = clamp(dt * 8, 0, 1);
-        active.radius += (targetRadius - active.radius) * blend;
-        active.radius = clamp(active.radius, active.minR, active.maxR);
-        active.radius = Math.max(active.minR, active.radius - active.shrinkRate * dt);
-        active.life -= dt;
-
-        const alpha = clamp(active.life / baseLife, 0.3, 1.0);
-        const pulseEffect = 1 + Math.sin(globalTime * 8) * 0.1;
-        
-        ctx.strokeStyle = fish.spec.ui.mapColorHex;
-        ctx.lineWidth = 4 * pulseEffect;
-        ctx.globalAlpha = alpha;
-        ctx.beginPath(); 
-        ctx.arc(bx, by, active.radius, 0, Math.PI * 2); 
-        ctx.stroke();
-        
-        if (active.radius <= active.minR + 8) {
-          ctx.strokeStyle = '#22c55e';
-          ctx.lineWidth = 2;
-          ctx.globalAlpha = alpha * 0.6;
-          ctx.beginPath(); 
-          ctx.arc(bx, by, active.minR, 0, Math.PI * 2); 
-          ctx.stroke();
-        }
-        
-        ctx.globalAlpha = 1;
-
-        if (active.life > 0 && active.radius > active.minR + 0.5) {
-          kept.push(active);
-        } else {
-          releaseActiveCircle(active, true);
-        }
-      }
-      world.actives = kept;
-    }
-
-    // === 유틸리티 함수들 ===
-    function showToast(msg) {
-      if (!toastEl) return;
-      toastEl.textContent = msg;
-      toastEl.classList.add('show');
-      setTimeout(() => toastEl.classList.remove('show'), 2000);
-    }
-
-    function showMissEffect() {
-      missEffect.classList.remove('show');
-      void missEffect.offsetWidth;
-      missEffect.classList.add('show');
-      setTimeout(() => missEffect.classList.remove('show'), 500);
-    }
-
-    function setHUD() {
-      energyEl.textContent = settings.energy;
-      pointsEl.textContent = settings.points;
-    }
-
-    function setGameplayLayout(gameplay) {
-      if (gameplay) {
-        title.style.display = 'none';
-        canvas.style.cursor = 'crosshair';
-        distanceEl.style.display = 'block';
-        document.querySelector('.hud').style.display = 'flex';
-      } else {
-        title.style.display = 'flex';
-        canvas.style.cursor = 'default';
-        distanceEl.style.display = 'none';
-        minimap.style.display = 'none';
-        gauge.style.display = 'none';
-      }
-    }
-
-    function resetCharacterToIdle() {
-      characterSprite.playing = false;
-      characterSprite.animationIndex = 0;
-      characterSprite.timer = 0;
-      characterSprite.currentFrame = characterSprite.idleFrame || 0;
-      characterSprite.holdFrame = characterSprite.postCastFrame ?? characterSprite.currentFrame;
-    }
-
-    function startCharacterCastAnimation() {
-      if (!characterSprite.castSequence.length) return;
-      characterSprite.playing = true;
-      characterSprite.animationIndex = 0;
-      characterSprite.timer = 0;
-      characterSprite.currentFrame = characterSprite.castSequence[0] ?? 0;
-      characterSprite.holdFrame = characterSprite.postCastFrame ?? characterSprite.castSequence[characterSprite.castSequence.length - 1] ?? characterSprite.currentFrame;
-    }
-
-    // 게임 초기화
-    async function init() {
-      // DOM 요소들 가져오기
-      canvas = document.getElementById('view');
-      ctx = canvas.getContext('2d');
-      startBtn = document.getElementById('startBtn');
-      title = document.getElementById('title');
-      gauge = document.getElementById('gauge');
-      bar = document.getElementById('bar');
-      sweet = document.getElementById('sweet');
-      cursor = document.getElementById('cursor');
-      toastEl = document.getElementById('toast');
-      missEffect = document.getElementById('missEffect');
-      distanceEl = document.getElementById('distance');
-      minimap = document.getElementById('minimap');
-      mmbar = document.getElementById('mmbar');
-      results = document.getElementById('results');
-      rTitle = document.getElementById('rTitle');
-      rBody = document.getElementById('rBody');
-      rNext = document.getElementById('rNext');
-      rSkip = document.getElementById('rSkip');
-      energyEl = document.getElementById('energy');
-      pointsEl = document.getElementById('points');
-
-      // 캔버스 크기 설정
-      function resizeCanvas() {
-        const rect = canvas.getBoundingClientRect();
-        canvas.width = rect.width;
-        canvas.height = rect.height;
-      }
-      resizeCanvas();
-      window.addEventListener('resize', resizeCanvas);
-
-      // 게임 에셋 로딩
-      const success = await loadGameAssets();
-      
-      if (success) {
-        startBtn.textContent = 'Touch to Start';
-        startBtn.classList.remove('disabled');
-        setHUD();
-      } else {
-        startBtn.textContent = 'Failed to Load - Retry';
-        startBtn.classList.add('error');
-      }
-
-      // 이벤트 리스너 설정
-      startBtn.addEventListener('click', async () => {
-        if (!dataLoaded || !assetsReady) {
-          startBtn.textContent = 'Loading Assets...';
-          startBtn.classList.add('disabled');
-          const success = await loadGameAssets();
-          if (success) {
-            startBtn.textContent = 'Touch to Start';
-            startBtn.classList.remove('disabled', 'error');
-          } else {
-            startBtn.textContent = 'Failed to Load - Retry';
-            startBtn.classList.add('error');
-          }
-          return;
-        }
-        if (state !== GameState.Idle) return;
-        if (settings.energy <= 0) { 
-          showToast('Not enough energy.'); 
-          return; 
-        }
-        startCasting();
-      });
-
-      canvas.addEventListener('click', () => {
-        if (state === GameState.Idle) startCasting();
-      });
-
-      window.addEventListener('pointerdown', () => {
-        if (state === GameState.Fishing) {
-          const anyActive = world.actives.length > 0;
-          let caughtNow = [];
-          for (const a of world.actives) {
-            const success = rollCatch(a);
-            if (success) caughtNow.push(a.fish);
-          }
-          if (caughtNow.length) {
-            for (const f of caughtNow) {
-              if (f.active) releaseActiveCircle(f.active, false);
-              f.finished = true;
-              f.engaged = false;
-              world.catches.push(f);
-            }
-            showResults();
-          } else if (anyActive) {
-            showMissEffect();
-          }
-        }
-      });
-
-      rNext.addEventListener('click', () => {
-        rIndex++;
-        if (rIndex < world.catches.length) {
-          renderResultCard();
-        } else {
-          results.style.display = 'none';
-          state = GameState.Idle;
-          title.style.display = 'flex';
-          resetCharacterToIdle();
-          setGameplayLayout(false);
-        }
-      });
-
-      rSkip.addEventListener('click', () => {
-        results.style.display = 'none';
-        state = GameState.Idle;
-        title.style.display = 'flex';
-        resetCharacterToIdle();
-        setGameplayLayout(false);
-      });
-    }
-
-    function startCasting() {
-      setGameplayLayout(true);
-      camera.y = 0;
-      settings.energy--; 
-      setHUD();
-      title.style.display = 'none';
-      gauge.style.display = 'flex';
-      state = GameState.Casting;
-      
-      const barRect = bar.getBoundingClientRect();
-      const w = barRect.width, cursorW = 5;
-      let dir = 1, x = 0;
-      const speed = w * 1.4;
-
-      function frame(ts) {
-        if (state !== GameState.Casting) return;
-        if (!frame.last) frame.last = ts;
-        const dt = (ts - frame.last)/1000; 
-        frame.last = ts;
-        x += dir * speed * dt;
-        if (x <= 0) { x = 0; dir = 1; }
-        if (x >= w - cursorW) { x = w - cursorW; dir = -1; }
-        cursor.style.left = x + 'px';
-        requestAnimationFrame(frame);
-      }
-      requestAnimationFrame(frame);
-
-      const stop = () => {
-        bar.removeEventListener('click', stop);
-        gauge.style.display = 'none';
-        const sweetRect = sweet.getBoundingClientRect();
-        const sweetCenter = sweetRect.left + sweetRect.width/2;
-        const cursorCenter = barRect.left + x + cursorW/2;
-        const dx = Math.abs(cursorCenter - sweetCenter);
-        const max = sweetRect.width/2;
-        const closeness = clamp(1 - dx / max, 0, 1);
-        const distance = Math.round(lerp(settings.baseCast, settings.maxCast, closeness));
-        startFlight(distance);
-      };
-      bar.addEventListener('click', stop);
-    }
-
-    function startFlight(dist) {
-      state = GameState.Flight;
-      world.castDistance = dist;
-      world.bobberDist = 0;
-      const metrics = getEnvironmentMetrics(canvas.clientWidth, canvas.clientHeight);
-      const spawnInfo = spawnFishes(dist, metrics, canvas.clientWidth);
-      world.fishes = spawnInfo.fishes;
-      world.actives = []; 
-      world.catches = [];
-      world.time = 0;
-      startCharacterCastAnimation();
-      distanceEl.style.display = 'block';
-      minimap.style.display = 'none';
-    }
-
-    function startFishing() {
-      state = GameState.Fishing;
-      world.bobberDist = world.castDistance;
-      minimap.style.display = 'block';
-      distanceEl.style.display = 'block';
-    }
-
-    let rIndex = 0;
-    function showResults() {
-      state = GameState.Results;
-      rIndex = 0;
-      results.style.display = 'flex';
-      minimap.style.display = 'none';
-      renderResultCard();
-    }
-
-    function renderResultCard() {
-      const count = world.catches.length;
-      if (rIndex >= count) {
-        rTitle.textContent = 'All Done!';
-        rBody.innerHTML = '<p>Great fishing session!</p>';
-        rNext.textContent = 'Continue';
-        return;
-      }
-
-      const fish = world.catches[rIndex];
-      const points = computePoints(fish, world.castDistance);
-      settings.points += points;
-      setHUD();
-
-      rTitle.textContent = `Catch ${rIndex + 1}/${count}`;
-      rBody.innerHTML = `
-        <div style="margin: 20px 0;">
-          <h4 style="color: ${fish.spec.ui.mapColorHex}; margin-bottom: 10px;">${fish.spec.displayName}</h4>
-          <p><strong>Size:</strong> ${fish.size_cm.toFixed(1)} cm</p>
-          <p><strong>Weight:</strong> ${fish.weight_kg.toFixed(2)} kg</p>
-          <p><strong>Rarity:</strong> ${fish.spec.rarity}</p>
-          <p><strong>Points:</strong> ${points}</p>
-        </div>
-      `;
-      rNext.textContent = rIndex < count - 1 ? 'Next' : 'Continue';
-    }
-
-    function updateMinimap() {
-      if (!mmbar) return;
-      
-      mmbar.innerHTML = '<div class="mmcenter"></div>';
-      
-      const mapWidth = 120;
-      const mapHeight = 60;
-      const range = 26;
-      
-      for (const fish of world.fishes) {
-        if (!fish || fish.finished) continue;
-        
-        const fishX = fish.position?.x ?? 0;
-        const fishY = fish.position?.y ?? fish.distance;
-        
-        const dx = fishX;
-        const dy = fishY - world.bobberDist;
-        const distance = Math.sqrt(dx * dx + dy * dy);
-        
-        if (distance <= DETECTION_RANGE_M) {
-          const dot = document.createElement('div');
-          dot.style.position = 'absolute';
-          dot.style.width = '4px';
-          dot.style.height = '4px';
-          dot.style.backgroundColor = fish.iconColor;
-          dot.style.borderRadius = '50%';
-          dot.style.left = (mapWidth * 0.5 + (fishX / range) * mapWidth * 0.4) + 'px';
-          dot.style.top = (mapHeight * 0.5 + (dy / range) * mapHeight * 0.4) + 'px';
-          dot.style.transform = 'translate(-50%, -50%)';
-          
-          if (fish.engaged) {
-            dot.style.border = '1px solid white';
-            dot.style.width = '6px';
-            dot.style.height = '6px';
-          }
-          
-          mmbar.appendChild(dot);
-        }
-      }
-      
-      const rangeCircle = document.createElement('div');
-      rangeCircle.style.position = 'absolute';
-      rangeCircle.style.left = '50%';
-      rangeCircle.style.top = '50%';
-      rangeCircle.style.transform = 'translate(-50%, -50%)';
-      rangeCircle.style.width = (DETECTION_RANGE_M / range * mapWidth * 0.8) + 'px';
-      rangeCircle.style.height = (DETECTION_RANGE_M / range * mapHeight * 0.8) + 'px';
-      rangeCircle.style.border = '1px solid rgba(91, 192, 190, 0.5)';
-      rangeCircle.style.borderRadius = '50%';
-      rangeCircle.style.pointerEvents = 'none';
-      mmbar.appendChild(rangeCircle);
-    }
-
-    // === 렌더링 함수 ===
-    function render() {
-      if (!canvas || !ctx) return;
-
-      const W = canvas.width;
-      const H = canvas.height;
-      
-      ctx.clearRect(0, 0, W, H);
-      
-      const metrics = getEnvironmentMetrics(W, H);
-      
-      drawEnvironment(W, H, metrics, camera.y);
-      drawCharacterSprite(W, H, metrics, camera.y);
-      
-      if (state === GameState.Flight) {
-        const progress = Math.min(world.time / 1.5, 1);
-        world.bobberDist = lerp(0, world.castDistance, progress);
-        
-        if (progress >= 1) {
-          startFishing();
-        }
-        
-        const distancePx = world.bobberDist * metrics.pxPerMeter;
-        const bobberWorldY = metrics.waterSurfaceY - distancePx;
-        const bobberScreenY = bobberWorldY + camera.y;
-        const bobberX = W * 0.5 + metrics.bobberOffsetX;
-        
-        drawFishingLine(rodAnchor.x, rodAnchor.y, bobberX, bobberScreenY);
-        drawBobber(bobberX, bobberScreenY);
-        
-      } else if (state === GameState.Fishing) {
-        const distancePx = world.bobberDist * metrics.pxPerMeter;
-        const bobberWorldY = metrics.waterSurfaceY - distancePx;
-        const bobberScreenY = bobberWorldY + camera.y;
-        const bobberX = W * 0.5 + metrics.bobberOffsetX;
-        
-        drawFishingLine(rodAnchor.x, rodAnchor.y, bobberX, bobberScreenY);
-        drawBobber(bobberX, bobberScreenY);
-        
-        for (const fish of world.fishes) {
-          if (!fish || fish.finished) continue;
-          
-          const fishDistPx = (fish.position?.y ?? fish.distance) * metrics.pxPerMeter;
-          const fishWorldY = metrics.waterSurfaceY - fishDistPx;
-          const fishScreenY = fishWorldY + camera.y;
-          const fishScreenX = W * 0.5 + (fish.position?.x ?? 0) * (W * 0.008);
-          
-          if (fishScreenY < -50 || fishScreenY > H + 50 || fishScreenX < -50 || fishScreenX > W + 50) {
-            continue;
-          }
-          
-          const fishImage = gameData.resources.fish.get(fish.specId);
-          if (fishImage) {
-            const fishScale = 0.8;
-            const fishW = fishImage.width * fishScale;
-            const fishH = fishImage.height * fishScale;
-            ctx.drawImage(fishImage, fishScreenX - fishW/2, fishScreenY - fishH/2, fishW, fishH);
-          } else {
-            // 향상된 폴백: 물고기 모양 그리기
-            const fishSize = 12;
-            ctx.fillStyle = fish.iconColor;
-            
-            // 물고기 몸체 (타원형)
-            ctx.beginPath();
-            ctx.ellipse(fishScreenX, fishScreenY, fishSize, fishSize * 0.6, 0, 0, Math.PI * 2);
-            ctx.fill();
-            
-            // 물고기 꼬리
-            ctx.beginPath();
-            ctx.moveTo(fishScreenX - fishSize, fishScreenY);
-            ctx.lineTo(fishScreenX - fishSize - 8, fishScreenY - 6);
-            ctx.lineTo(fishScreenX - fishSize - 8, fishScreenY + 6);
-            ctx.closePath();
-            ctx.fill();
-            
-            // 물고기 지느러미
-            ctx.fillStyle = `${fish.iconColor}80`; // 반투명
-            ctx.beginPath();
-            ctx.ellipse(fishScreenX + 2, fishScreenY - 8, 4, 3, 0, 0, Math.PI * 2);
-            ctx.fill();
-            
-            // 물고기 눈
-            ctx.fillStyle = '#ffffff';
-            ctx.beginPath();
-            ctx.arc(fishScreenX + 4, fishScreenY - 2, 2, 0, Math.PI * 2);
-            ctx.fill();
-            ctx.fillStyle = '#000000';
-            ctx.beginPath();
-            ctx.arc(fishScreenX + 4, fishScreenY - 2, 1, 0, Math.PI * 2);
-            ctx.fill();
-          }
-          
-          if (fish.engaged) {
-            ctx.strokeStyle = fish.iconColor;
-            ctx.lineWidth = 2;
-            ctx.setLineDash([5, 5]);
-            ctx.beginPath();
-            ctx.arc(fishScreenX, fishScreenY, 15, 0, Math.PI * 2);
-            ctx.stroke();
-            ctx.setLineDash([]);
-          }
-        }
-        
-        updateActiveCircles(1/60, bobberX, bobberScreenY, metrics, camera.y);
-        updateMinimap();
-      }
-      
-      if (state === GameState.Flight || state === GameState.Fishing) {
-        distanceEl.textContent = `Distance: ${Math.round(world.bobberDist)}m`;
-      }
-    }
-
-    // === 게임 루프 ===
-    let lastTime = 0;
-    function gameLoop(currentTime) {
-      const dt = Math.min((currentTime - lastTime) / 1000, 1/30);
-      lastTime = currentTime;
-      globalTime += dt;
-      world.time += dt;
-      
-      updateCharacterAnimation(dt);
-      updateFishSimulation(dt);
-      
-      if (state === GameState.Flight || state === GameState.Fishing) {
-        const metrics = getEnvironmentMetrics(canvas.width, canvas.height);
-        updateCamera(world.bobberDist, metrics, dt, state);
-      }
-      
-      render();
-      requestAnimationFrame(gameLoop);
-    }
-
-    // === 게임 시작 ===
-    document.addEventListener('DOMContentLoaded', async () => {
-      await init();
-      requestAnimationFrame(gameLoop);
-    });
-
-    // 에너지 회복 시스템
-    setInterval(() => {
-      if (settings.energy < 10) {
-        settings.energy++;
-        setHUD();
-      }
-    }, 30000);
-  </script>
 </body>
 </html>

--- a/js/gameplay.js
+++ b/js/gameplay.js
@@ -13,34 +13,71 @@ function sampleSpecies() {
 }
 
 // 물고기 스폰
-function spawnFishes(dist, metrics, viewportWidth) {
-  if (!SPECIES.length) return { fishes: [], lateralLimit: 26, displayRange: 26 };
-  
-  const ratio = clamp(dist / settings.maxCast, 0.2, 1);
-  const count = randi(4 + ratio * 2, 6 + ratio * 3);
+function spawnFishes(dist, options = {}) {
+  const halfWidth = options.halfWidth ?? 5;
+  if (!SPECIES.length) return { fishes: [], lateralLimit: halfWidth, displayRange: halfWidth };
+
+  const spread = !!options.spread;
   const fishes = [];
-  
-  for (let i = 0; i < count; i++) {
+  const minDistance = 30;
+  const maxDistance = spread ? 200 : Math.min(dist + 20, 200);
+  const segmentSize = Math.max(2, window.MINIMAP_SEGMENT_METERS || 5);
+  const fishMap = gameData?.resources?.fish;
+
+  const sampleLateral = () => rand(-halfWidth, halfWidth);
+
+  const spawnAtDistance = distance => {
     const spec = sampleSpecies();
-    if (!spec) continue;
-    
+    if (!spec) return;
+
     const size = rand(spec.size_cm.min, spec.size_cm.max);
     const weight = rand(spec.weight_kg.min, spec.weight_kg.max);
-    const distance = rand(30, Math.min(dist + 20, 200));
-    const lateral = rand(-26, 26);
-    
-    const fishMap = gameData?.resources?.fish;
+    const lateral = sampleLateral();
     const cachedImage = fishMap?.get?.(spec.id);
-    
+
     const fish = {
-      specId: spec.id, spec, distance, size_cm: size, weight_kg: weight, engaged: false, finished: false,
-      iconColor: spec.ui.mapColorHex, position: { x: lateral, y: distance },
-      velocity: { x: 0, y: 0 }, targetVelocity: { x: 0, y: 0 }, bonusMultiplier: 1,
-      escapeTimer: 0, lastCircleTime: -Infinity, renderCache: null, image: cachedImage || null, active: null,
-      stressLevel: 0, personalityFactor: rand(0.8, 1.2), moveBias: getFishMoveBias(spec),
+      specId: spec.id,
+      spec,
+      distance,
+      size_cm: size,
+      weight_kg: weight,
+      engaged: false,
+      finished: false,
+      iconColor: spec.ui.mapColorHex,
+      position: { x: lateral, y: distance },
+      velocity: { x: 0, y: 0 },
+      targetVelocity: { x: 0, y: 0 },
+      bonusMultiplier: 1,
+      escapeTimer: 0,
+      lastCircleTime: -Infinity,
+      renderCache: null,
+      image: cachedImage || null,
+      active: null,
+      stressLevel: 0,
+      personalityFactor: rand(0.8, 1.2),
+      moveBias: getFishMoveBias(spec),
+      facingRight: Math.random() > 0.5,
       swimSpeed: getFishSwimSpeed(spec, weight)
     };
+
     fishes.push(fish);
+  };
+
+  if (spread) {
+    for (let base = minDistance; base <= maxDistance; base += segmentSize) {
+      const count = randi(3, 4);
+      for (let i = 0; i < count; i++) {
+        const offset = rand(-segmentSize * 0.45, segmentSize * 0.45);
+        const distance = clamp(base + offset, minDistance, maxDistance);
+        spawnAtDistance(distance);
+      }
+    }
+  } else {
+    const density = randi(12, 18);
+    for (let i = 0; i < density; i++) {
+      const distance = clamp(rand(minDistance, maxDistance), minDistance, maxDistance);
+      spawnAtDistance(distance);
+    }
   }
   
   // 보너스 물고기 설정
@@ -53,9 +90,9 @@ function spawnFishes(dist, metrics, viewportWidth) {
       if (rare) rare.bonusMultiplier = 3;
     }
   }
-  
+
   fishes.sort((a, b) => a.distance - b.distance);
-  return { fishes, lateralLimit: 52, displayRange: 26 };
+  return { fishes, lateralLimit: halfWidth, displayRange: halfWidth };
 }
 
 // === 개선된 잡기 확률 시스템 ===
@@ -248,10 +285,10 @@ function updateActiveCircles(dt, bx, by, metrics, cameraY) {
 // 투영 컨텍스트 해결
 function resolveProjectionContext(metrics) {
   const pxPerMeter = metrics?.pxPerMeter || (canvas.clientHeight / Math.max(1, settings.maxCast));
-  const displayRange = 26;
+  const displayRange = Math.max(1, world.displayRange || world.lateralLimit || 5);
   const width = canvas.clientWidth;
   const centerX = width * 0.5;
-  const pxPerMeterX = (width * 0.45) / displayRange;
+  const pxPerMeterX = (width * 0.82) / (displayRange * 2);
   return { pxPerMeter, displayRange, pxPerMeterX, centerX, width };
 }
 

--- a/js/main.js
+++ b/js/main.js
@@ -1,320 +1,1049 @@
-// === 메인 게임 로직 ===
+// Main game bootstrap and high-level orchestration logic.
+// Relies on global state defined in state.js and helpers from utils.js.
 
-// 데이터 로딩
-async function loadGameData() {
-  if (loadingPromise) return loadingPromise;
+(function () {
+  function ensureDomReferences() {
+    window.canvas = document.getElementById('view');
+    window.ctx = window.canvas?.getContext('2d') ?? null;
+    window.startBtn = document.getElementById('startBtn');
+    window.mainMenu = document.getElementById('mainMenu');
+    window.titleBar = document.getElementById('titleBar');
+    window.navBar = document.getElementById('navBar');
+    window.exitBtn = document.getElementById('exitBtn');
+    window.shopBtn = document.getElementById('shopBtn');
+    window.rankBtn = document.getElementById('rankBtn');
+    window.premiumBtn = document.getElementById('premiumBtn');
+    window.castPrompt = document.getElementById('castPrompt');
+    window.toastEl = document.getElementById('toast');
+    window.missEffect = document.getElementById('missEffect');
+    window.distanceEl = document.getElementById('distance');
+    window.minimap = document.getElementById('minimap');
+    window.mmbar = document.getElementById('mmbar');
+    window.mmCells = document.getElementById('mmcells');
+    window.mmViewport = document.getElementById('mmviewport');
+    window.mmIndicator = document.getElementById('mmbobber');
+    window.results = document.getElementById('results');
+    window.rTitle = document.getElementById('rTitle');
+    window.rBody = document.getElementById('rBody');
+    window.rNext = document.getElementById('rNext');
+    window.rSkip = document.getElementById('rSkip');
+    window.energyEl = document.getElementById('energy');
+    window.pointsEl = document.getElementById('points');
 
-  startBtn.textContent = 'Loading data...';
-  startBtn.classList.add('disabled');
-  startBtn.classList.remove('error');
-
-  loadingPromise = (async () => {
-    try {
-      const response = await fetch(DATA_URL, { cache: 'no-cache' });
-      if (!response.ok) throw new Error(`HTTP ${response.status}`);
-      const data = await response.json();
-      hydrateGameData(data);
-      await prepareAssets();
-      dataLoaded = true;
-      startBtn.textContent = 'Touch to Start';
-      startBtn.classList.remove('disabled', 'error');
-      return true;
-    } catch (err) {
-      console.error('Failed to load game data:', err);
-      dataLoaded = false;
-      assetsReady = false;
-      startBtn.textContent = 'Retry Data Load';
-      startBtn.classList.remove('disabled');
-      startBtn.classList.add('error');
-      toast('Failed to load fish data');
-      return false;
-    } finally {
-      loadingPromise = null;
+    if (!window.canvas || !window.ctx || !window.startBtn || !window.mainMenu) {
+      throw new Error('Essential DOM elements are missing.');
     }
-  })();
-  return loadingPromise;
-}
-
-// 게임 데이터 하이드레이션
-function hydrateGameData(data) {
-  gameData.assets = data.assets || {};
-  gameData.species = Array.isArray(data.species) ? data.species : [];
-  gameData.characters = Array.isArray(data.characters) ? data.characters : [];
-  gameData.environment = data.environment || null;
-  gameData.player = data.player || null;
-  SPECIES = gameData.species;
-  CHARACTERS = gameData.characters;
-  if (gameData.resources?.icons) gameData.resources.icons.star = null;
-
-  const env = gameData.environment || {};
-  if (env.tileWidth > 0) environmentState.tileWidth = env.tileWidth;
-  if (env.tileHeight > 0) environmentState.tileHeight = env.tileHeight;
-  if (env.landRows > 0) environmentState.landRows = Math.max(1, Math.floor(env.landRows));
-  environmentState.sources = { 
-    water: env.waterTile || null, 
-    shore: env.shoreTile || null, 
-    land: env.landTile || null 
-  };
-  applyPlayerConfig();
-}
-
-// 플레이어 설정 적용
-function applyPlayerConfig() {
-  const base = gameData.player || {};
-  const playerChar = CHARACTERS.find(c => c && c.role === 'Player') || null;
-  const charAnim = playerChar?.animation || {};
-  
-  characterSprite.spriteSource = base.spriteSheet || charAnim.spriteSheet || characterSprite.spriteSource;
-  characterSprite.frameWidth = base.frameWidth || charAnim.frameWidth || characterSprite.frameWidth;
-  characterSprite.frameHeight = base.frameHeight || charAnim.frameHeight || characterSprite.frameHeight;
-  characterSprite.frameCount = base.frameCount || charAnim.frameCount || characterSprite.frameCount;
-  characterSprite.idleFrame = base.idleFrame ?? charAnim.idleFrame ?? characterSprite.idleFrame;
-  characterSprite.postCastFrame = base.postCastFrame ?? charAnim.postCastFrame ?? characterSprite.postCastFrame;
-  if (base.castSequence || charAnim.castSequence) {
-    characterSprite.castSequence = (base.castSequence || charAnim.castSequence).slice();
-  }
-  characterSprite.frameDuration = (base.frameDurationMs || charAnim.frameDurationMs || characterSprite.frameDuration * 1000) / 1000;
-  characterSprite.scale = base.scale || charAnim.scale || characterSprite.scale;
-  characterSprite.lineAnchor = base.lineAnchor || charAnim.lineAnchor || characterSprite.lineAnchor;
-  characterSprite.holdFrame = characterSprite.postCastFrame ?? characterSprite.castSequence[characterSprite.castSequence.length - 1] ?? 0;
-  if (!characterSprite.castSequence.length) {
-    characterSprite.castSequence = [characterSprite.idleFrame, characterSprite.postCastFrame];
-  }
-  resetCharacterToIdle();
-}
-
-function resetCharacterToIdle() {
-  characterSprite.playing = false;
-  characterSprite.animationIndex = 0;
-  characterSprite.timer = 0;
-  characterSprite.currentFrame = characterSprite.idleFrame || 0;
-  characterSprite.holdFrame = characterSprite.postCastFrame ?? characterSprite.currentFrame;
-}
-
-function startCharacterCastAnimation() {
-  if (!characterSprite.castSequence.length) return;
-  characterSprite.playing = true;
-  characterSprite.animationIndex = 0;
-  characterSprite.timer = 0;
-  characterSprite.currentFrame = characterSprite.castSequence[0] ?? 0;
-  characterSprite.holdFrame = characterSprite.postCastFrame ?? characterSprite.castSequence[characterSprite.castSequence.length - 1] ?? characterSprite.currentFrame;
-}
-
-// 에셋 준비
-async function prepareAssets() {
-  if (assetsReady) return true;
-  if (assetPrepPromise) return assetPrepPromise;
-
-  const tasks = [];
-  const seen = new Map();
-  const fishCache = new Map();
-
-  const queue = (src, assign) => {
-    if (!src) return;
-    let loader = seen.get(src);
-    if (!loader) {
-      loader = loadImage(src);
-      seen.set(src, loader);
-    }
-    tasks.push(loader.then(img => assign(img)).catch(err => console.warn('Asset load failed:', src, err)));
-  };
-
-  for (const spec of SPECIES) {
-    const imgInfo = spec.images || {};
-    const src = imgInfo.card || imgInfo.illustration || imgInfo.sprite || imgInfo.spriteSheet;
-    if (!src) continue;
-    queue(src, img => fishCache.set(spec.id, img));
   }
 
-  const sources = environmentState.sources || {};
-  queue(sources.water, img => { environmentState.water = img; });
-  queue(sources.shore, img => { 
-    environmentState.shore = img; 
-    if (!gameData.environment?.tileWidth) environmentState.tileWidth = img.width; 
-    if (!gameData.environment?.tileHeight) environmentState.tileHeight = img.height; 
-  });
-  queue(sources.land, img => { environmentState.land = img; });
-  if (characterSprite.spriteSource) {
-    queue(characterSprite.spriteSource, img => { characterSprite.image = img; });
+  function resizeCanvas() {
+    if (!window.canvas) return;
+    const rect = window.canvas.getBoundingClientRect();
+    window.canvas.width = rect.width;
+    window.canvas.height = rect.height;
   }
 
-  assetPrepPromise = Promise.all(tasks).then(() => {
-    gameData.resources.fish = fishCache;
-    assetsReady = true;
-    initPassingSchool(passingSchoolMode);
-    resetCharacterToIdle();
-    return true;
-  }).catch(err => {
-    assetsReady = false;
-    throw err;
-  }).finally(() => {
-    assetPrepPromise = null;
-  });
+  async function loadGameData() {
+    if (window.loadingPromise) return window.loadingPromise;
 
-  return assetPrepPromise;
-}
+    window.startBtn.textContent = 'Loading data...';
+    window.startBtn.classList.add('disabled');
+    window.startBtn.classList.remove('error');
 
-// 패싱 스쿨 초기화
-function initPassingSchool(mode = 'title') {
-  passingSchoolMode = mode;
-  if (mode !== 'title') { 
-    passingSchool = []; 
-    return; 
-  }
-  
-  const entries = Array.from(gameData.resources.fish.entries());
-  if (!entries.length) { 
-    passingSchool = []; 
-    return; 
-  }
-  
-  const count = Math.min(18, Math.max(8, entries.length * 2));
-  passingSchool = Array.from({ length: count }, (_, i) => {
-    const [id, img] = entries[i % entries.length];
-    return { 
-      id, img, 
-      scale: 0.55 + Math.random() * 0.45, 
-      baseX: Math.random(), 
-      baseY: Math.random(), 
-      xAmp: 0.35 + Math.random() * 0.4, 
-      yAmp: 0.25 + Math.random() * 0.35, 
-      xSpeed: 0.6 + Math.random() * 1.0, 
-      ySpeed: 0.45 + Math.random() * 0.85, 
-      phaseX: Math.random() * Math.PI * 2, 
-      phaseY: Math.random() * Math.PI * 2 
-    };
-  });
-}
-
-// 게임 시작
-startBtn.textContent = 'Loading data...';
-startBtn.classList.add('disabled');
-loadGameData();
-
-// 이벤트 핸들러들
-startBtn.addEventListener('click', () => {
-  if (!dataLoaded) {
-    if (loadingPromise) toast('Loading data...'); 
-    else { loadGameData(); toast('Reloading data...'); }
-    return;
-  }
-  if (state !== GameState.Idle) return;
-  if (settings.energy <= 0) { toast('Not enough energy.'); return; }
-  startCasting();
-});
-
-function startCasting() {
-  setGameplayLayout(true);
-  camera.y = 0;
-  settings.energy--; 
-  setHUD();
-  title.style.display = 'none';
-  gauge.style.display = 'flex';
-  state = GameState.Casting;
-  
-  const barRect = bar.getBoundingClientRect();
-  const w = barRect.width, cursorW = 5;
-  let dir = 1, x = 0;
-  const speed = w * 1.4;
-
-  function frame(ts) {
-    if (state !== GameState.Casting) return;
-    if (!frame.last) frame.last = ts;
-    const dt = (ts - frame.last)/1000; 
-    frame.last = ts;
-    x += dir * speed * dt;
-    if (x <= 0) { x = 0; dir = 1; }
-    if (x >= w - cursorW) { x = w - cursorW; dir = -1; }
-    cursor.style.left = x + 'px';
-    requestAnimationFrame(frame);
-  }
-  requestAnimationFrame(frame);
-
-  const stop = () => {
-    bar.removeEventListener('click', stop);
-    gauge.style.display = 'none';
-    const sweetRect = sweet.getBoundingClientRect();
-    const sweetCenter = sweetRect.left + sweetRect.width/2;
-    const cursorCenter = barRect.left + x + cursorW/2;
-    const dx = Math.abs(cursorCenter - sweetCenter);
-    const max = sweetRect.width/2;
-    const closeness = clamp(1 - dx / max, 0, 1);
-    const distance = Math.round(lerp(settings.baseCast, settings.maxCast, closeness));
-    startFlight(distance);
-  };
-  bar.addEventListener('click', stop);
-}
-
-function startFlight(dist) {
-  state = GameState.Flight;
-  world.castDistance = dist;
-  world.bobberDist = 0;
-  const metrics = getEnvironmentMetrics(canvas.clientWidth, canvas.clientHeight);
-  const spawnInfo = spawnFishes(dist, metrics, canvas.clientWidth);
-  world.fishes = spawnInfo.fishes;
-  world.lateralLimit = spawnInfo.lateralLimit;
-  world.displayRange = spawnInfo.displayRange;
-  world.actives = []; 
-  world.catches = [];
-  world.time = 0;
-  startCharacterCastAnimation();
-  distanceEl.style.display = 'block';
-  minimap.style.display = 'none';
-}
-
-function startFishing() {
-  state = GameState.Fishing;
-  world.bobberDist = world.castDistance;
-  minimap.style.display = 'block';
-  distanceEl.style.display = 'block';
-}
-
-function endRunNoCatch() {
-  toast('No Fish Caught');
-  setTimeout(() => {
-    state = GameState.Idle;
-    title.style.display = 'flex';
-    resetCharacterToIdle();
-    setGameplayLayout(false);
-  }, 700);
-}
-
-// 입력 처리
-window.addEventListener('pointerdown', () => {
-  if (state === GameState.Fishing) {
-    const anyActive = world.actives.length > 0;
-    let caughtNow = [];
-    for (const a of world.actives) {
-      const success = rollCatch(a);
-      if (success) caughtNow.push(a.fish);
-    }
-    if (caughtNow.length) {
-      for (const f of caughtNow) {
-        if (f.active) releaseActiveCircle(f.active, false);
-        f.finished = true;
-        f.engaged = false;
-        world.catches.push(f);
+    window.loadingPromise = (async () => {
+      try {
+        const response = await fetch(window.DATA_URL, { cache: 'no-cache' });
+        if (!response.ok) throw new Error(`HTTP ${response.status}`);
+        const data = await response.json();
+        hydrateGameData(data);
+        await prepareAssets();
+        window.dataLoaded = true;
+        window.startBtn.textContent = 'Game Play';
+        window.startBtn.classList.remove('disabled', 'error');
+        return true;
+      } catch (err) {
+        console.error('Failed to load game data:', err);
+        window.dataLoaded = false;
+        window.assetsReady = false;
+        window.startBtn.textContent = 'Retry Data Load';
+        window.startBtn.classList.remove('disabled');
+        window.startBtn.classList.add('error');
+        window.toast('Failed to load fish data');
+        return false;
+      } finally {
+        window.loadingPromise = null;
       }
-      showResults();
-    } else if (anyActive) {
-      showMissEffect(); // 개선된 Miss 이펙트
+    })();
+
+    return window.loadingPromise;
+  }
+
+  function hydrateGameData(data) {
+    window.gameData.assets = data.assets || {};
+    window.gameData.species = Array.isArray(data.species) ? data.species : [];
+    window.gameData.characters = Array.isArray(data.characters) ? data.characters : [];
+    window.gameData.environment = data.environment || null;
+    window.gameData.player = data.player || null;
+    window.SPECIES = window.gameData.species;
+    window.CHARACTERS = window.gameData.characters;
+    if (window.gameData.resources?.icons) {
+      window.gameData.resources.icons.star = null;
+    }
+
+    const env = window.gameData.environment || {};
+    if (env.tileWidth > 0) window.environmentState.tileWidth = env.tileWidth;
+    if (env.tileHeight > 0) window.environmentState.tileHeight = env.tileHeight;
+    if (env.landRows > 0) window.environmentState.landRows = Math.max(1, Math.floor(env.landRows));
+    window.environmentState.sources = {
+      water: env.waterTile || null,
+      shore: env.shoreTile || null,
+      land: env.landTile || null
+    };
+
+    applyPlayerConfig();
+  }
+
+  function applyPlayerConfig() {
+    const base = window.gameData.player || {};
+    const playerChar = window.CHARACTERS.find(c => c && c.role === 'Player') || null;
+    const charAnim = playerChar?.animation || {};
+
+    window.characterSprite.spriteSource = base.spriteSheet || charAnim.spriteSheet || window.characterSprite.spriteSource;
+    window.characterSprite.frameWidth = base.frameWidth || charAnim.frameWidth || window.characterSprite.frameWidth;
+    window.characterSprite.frameHeight = base.frameHeight || charAnim.frameHeight || window.characterSprite.frameHeight;
+    window.characterSprite.frameCount = base.frameCount || charAnim.frameCount || window.characterSprite.frameCount;
+    window.characterSprite.idleFrame = base.idleFrame ?? charAnim.idleFrame ?? window.characterSprite.idleFrame;
+    window.characterSprite.postCastFrame = base.postCastFrame ?? charAnim.postCastFrame ?? window.characterSprite.postCastFrame;
+    if (base.castSequence || charAnim.castSequence) {
+      window.characterSprite.castSequence = (base.castSequence || charAnim.castSequence).slice();
+    }
+    const frameDuration = base.frameDurationMs || charAnim.frameDurationMs;
+    if (frameDuration) window.characterSprite.frameDuration = frameDuration / 1000;
+    window.characterSprite.scale = base.scale || charAnim.scale || window.characterSprite.scale;
+    window.characterSprite.lineAnchor = base.lineAnchor || charAnim.lineAnchor || window.characterSprite.lineAnchor;
+    window.characterSprite.holdFrame = window.characterSprite.postCastFrame
+      ?? window.characterSprite.castSequence[window.characterSprite.castSequence.length - 1]
+      ?? 0;
+    if (!window.characterSprite.castSequence.length) {
+      window.characterSprite.castSequence = [window.characterSprite.idleFrame, window.characterSprite.postCastFrame];
+    }
+    resetCharacterToIdle();
+  }
+
+  function resetCharacterToIdle() {
+    window.characterSprite.playing = false;
+    window.characterSprite.animationIndex = 0;
+    window.characterSprite.timer = 0;
+    window.characterSprite.currentFrame = window.characterSprite.idleFrame || 0;
+    window.characterSprite.holdFrame = window.characterSprite.postCastFrame ?? window.characterSprite.currentFrame;
+  }
+
+  function startCharacterCastAnimation() {
+    if (!window.characterSprite.castSequence.length) return;
+    window.characterSprite.playing = true;
+    window.characterSprite.animationIndex = 0;
+    window.characterSprite.timer = 0;
+    window.characterSprite.currentFrame = window.characterSprite.castSequence[0] ?? 0;
+    window.characterSprite.holdFrame = window.characterSprite.postCastFrame
+      ?? window.characterSprite.castSequence[window.characterSprite.castSequence.length - 1]
+      ?? window.characterSprite.currentFrame;
+  }
+
+  async function prepareAssets() {
+    if (window.assetsReady) return true;
+    if (window.assetPrepPromise) return window.assetPrepPromise;
+
+    const tasks = [];
+    const seen = new Map();
+    const fishCache = new Map();
+
+    const queue = (src, assign) => {
+      if (!src) return;
+      let loader = seen.get(src);
+      if (!loader) {
+        loader = window.loadImage(src);
+        seen.set(src, loader);
+      }
+      tasks.push(loader.then(img => assign(img)).catch(err => console.warn('Asset load failed:', src, err)));
+    };
+
+    for (const spec of window.SPECIES) {
+      const imgInfo = spec.images || {};
+      const src = imgInfo.card || imgInfo.illustration || imgInfo.sprite || imgInfo.spriteSheet;
+      if (!src) continue;
+      queue(src, img => fishCache.set(spec.id, img));
+    }
+
+    const sources = window.environmentState.sources || {};
+    queue(sources.water, img => { window.environmentState.water = img; });
+    queue(sources.shore, img => {
+      window.environmentState.shore = img;
+      if (!window.gameData.environment?.tileWidth) window.environmentState.tileWidth = img.width;
+      if (!window.gameData.environment?.tileHeight) window.environmentState.tileHeight = img.height;
+    });
+    queue(sources.land, img => { window.environmentState.land = img; });
+    if (window.characterSprite.spriteSource) {
+      queue(window.characterSprite.spriteSource, img => { window.characterSprite.image = img; });
+    }
+
+    window.assetPrepPromise = Promise.all(tasks).then(() => {
+      window.gameData.resources.fish = fishCache;
+      window.assetsReady = true;
+      initPassingSchool(window.passingSchoolMode);
+      resetCharacterToIdle();
+      return true;
+    }).catch(err => {
+      window.assetsReady = false;
+      throw err;
+    }).finally(() => {
+      window.assetPrepPromise = null;
+    });
+
+    return window.assetPrepPromise;
+  }
+
+  function initPassingSchool(mode = 'title') {
+    window.passingSchoolMode = mode;
+    if (mode !== 'title') {
+      window.passingSchool = [];
+      return;
+    }
+
+    const entries = Array.from(window.gameData.resources.fish.entries());
+    if (!entries.length) {
+      window.passingSchool = [];
+      return;
+    }
+
+    const count = Math.min(18, Math.max(8, entries.length * 2));
+    window.passingSchool = Array.from({ length: count }, (_, i) => {
+      const [id, img] = entries[i % entries.length];
+      const lane = (i + Math.random() * 0.8 + 0.2) / (count + 0.4);
+      const baseX = Math.min(0.95, Math.max(0.05, lane));
+      const baseY = 0.18 + Math.random() * 0.64;
+      const xDrift = 0.08 + Math.random() * 0.25;
+      const yDrift = 0.08 + Math.random() * 0.22;
+      return {
+        id,
+        img,
+        scale: 0.55 + Math.random() * 0.45,
+        baseX,
+        baseY,
+        xAmp: xDrift,
+        yAmp: yDrift,
+        xSpeed: 0.35 + Math.random() * 0.85,
+        ySpeed: 0.3 + Math.random() * 0.65,
+        phaseX: Math.random() * Math.PI * 2,
+        phaseY: Math.random() * Math.PI * 2
+      };
+    });
+  }
+
+  function drawPassingSchool(W, H, metrics) {
+    if (!window.passingSchool.length || !window.ctx) return;
+    const time = window.globalTime;
+    const waterTop = Math.max(20, (metrics?.topMargin || H * 0.2) * 0.45);
+    const waterBottom = Math.max(waterTop + 80, (metrics?.shorelineY ?? H * 0.8) - (metrics?.tileH ?? 40) * 0.5);
+    const waterHeight = waterBottom - waterTop;
+    const lateralMargin = W * 0.08;
+    const usableWidth = Math.max(40, W - lateralMargin * 2);
+    for (const fish of window.passingSchool) {
+      const sinX = Math.sin(time * fish.xSpeed + fish.phaseX);
+      const sinY = Math.sin(time * fish.ySpeed + fish.phaseY);
+      const centerX = lateralMargin + usableWidth * (fish.baseX ?? 0.5);
+      const offsetX = sinX * (fish.xAmp ?? 0.1) * usableWidth * 0.5;
+      const x = centerX + offsetX;
+      const centerY = waterTop + waterHeight * (fish.baseY ?? 0.5);
+      const offsetY = sinY * (fish.yAmp ?? 0.1) * waterHeight * 0.5;
+      const y = centerY + offsetY;
+      const img = fish.img;
+      if (!img) continue;
+      const scale = fish.scale * 0.7;
+      const width = img.width * scale;
+      const height = img.height * scale;
+      const dir = Math.cos(time * fish.xSpeed + fish.phaseX) * fish.xSpeed;
+      const facingRight = dir > 0;
+      window.ctx.save();
+      window.ctx.globalAlpha = 0.55;
+      window.ctx.translate(x, y);
+      if (facingRight) window.ctx.scale(-1, 1);
+      window.ctx.drawImage(img, -width / 2, -height / 2, width, height);
+      window.ctx.restore();
     }
   }
-});
 
-canvas.addEventListener('click', () => {
-  if (state === GameState.Idle) startCasting();
-});
+  const TARGET_MIN_DISTANCE = window.MIN_CAST_DISTANCE ?? 30;
+  const TARGET_MAX_DISTANCE = 150;
+  const TARGET_SPEED_BASE = 22;
+  const SINK_DURATION = 3;
+  const SINK_DISTANCE_DROP = 12;
+  const SINK_MIN_DISTANCE = window.MIN_SINK_DISTANCE ?? TARGET_MIN_DISTANCE * 0.8;
+  const WORLD_HALF_WIDTH = 5;
 
-// 결과 화면
-let rIndex = 0;
-function showResults() {
-  state = GameState.Results;
-  rIndex = 0;
-  results.style.display = 'flex';
-  minimap.style.display = 'none';
-  renderResultCard();
-}
+  function setCastPrompt(visible, message) {
+    if (!window.castPrompt) return;
+    if (typeof message === 'string') {
+      window.castPrompt.textContent = message;
+    }
+    window.castPrompt.classList.toggle('show', !!visible);
+  }
 
-function renderResultCard() {
-  const count = world.catches.length;
+  function resetTargetCircle() {
+    window.world.targetCircle = {
+      distance: TARGET_MIN_DISTANCE,
+      velocity: 0,
+      holding: false,
+      holdTime: 0,
+      reachedTop: false
+    };
+    window.world.castStage = 'aiming';
+    window.world.bobberVisible = false;
+    window.world.bobberDist = TARGET_MIN_DISTANCE;
+    window.world.castDistance = TARGET_MIN_DISTANCE;
+    window.world.sinkTimer = 0;
+    window.world.sinkDuration = 0;
+    window.world.sinkStartDist = TARGET_MIN_DISTANCE;
+    window.world.sinkEndDist = TARGET_MIN_DISTANCE;
+    window.world.pendingCatchSims = [];
+  }
+
+  function updateDistanceReadout() {
+    if (!window.distanceEl) return;
+    window.distanceEl.textContent = `Distance: ${Math.round(window.world.bobberDist)}m`;
+  }
+
+  function respawnFishPopulation() {
+    const spawnInfo = spawnFishes(window.settings.maxCast, { spread: true, halfWidth: WORLD_HALF_WIDTH });
+    window.world.fishes = spawnInfo.fishes;
+    window.world.lateralLimit = spawnInfo.lateralLimit;
+    window.world.displayRange = spawnInfo.displayRange;
+  }
+
+  function preparePlayRound(respawn = true) {
+    window.state = window.GameState.Targeting;
+    window.camera.y = 0;
+    window.world.actives = [];
+    window.world.catches = [];
+    window.world.pendingCatchSims = [];
+    window.resultsIndex = 0;
+    window.world.time = 0;
+    window.world.targetZoom = 1;
+    window.world.viewZoom = 1;
+    window.world.bobberVisible = false;
+    if (respawn || !Array.isArray(window.world.fishes) || !window.world.fishes.length) {
+      respawnFishPopulation();
+    } else {
+      for (const fish of window.world.fishes) {
+        if (!fish) continue;
+        fish.finished = false;
+        fish.engaged = false;
+        fish.active = null;
+        fish.escapeTimer = 0;
+      }
+    }
+    resetTargetCircle();
+    clearCatchSimulations();
+    updateDistanceReadout();
+    if (window.minimap) window.minimap.style.display = 'flex';
+    if (window.distanceEl) window.distanceEl.style.display = 'block';
+    setCastPrompt(true, 'Press the Screen to cast the bobber');
+    resetCharacterToIdle();
+  }
+
+  function exitToMenu() {
+    window.state = window.GameState.Idle;
+    window.camera.y = 0;
+    setCastPrompt(false);
+    awardRemainingCatchPoints();
+    window.world.targetCircle = null;
+    window.world.actives = [];
+    window.world.catches = [];
+    window.world.fishes = [];
+    window.world.targetZoom = 1;
+    window.world.viewZoom = 1;
+    window.world.bobberDist = TARGET_MIN_DISTANCE;
+    window.world.castDistance = TARGET_MIN_DISTANCE;
+    window.world.castStage = 'idle';
+    window.world.bobberVisible = false;
+    window.world.sinkTimer = 0;
+    window.world.sinkDuration = 0;
+    window.world.sinkStartDist = TARGET_MIN_DISTANCE;
+    window.world.sinkEndDist = TARGET_MIN_DISTANCE;
+    window.world.pendingCatchSims = [];
+    clearCatchSimulations();
+    window.resultsIndex = 0;
+    if (window.results) window.results.style.display = 'none';
+    if (window.minimap) window.minimap.style.display = 'none';
+    if (window.distanceEl) window.distanceEl.style.display = 'none';
+    resetCharacterToIdle();
+    window.setGameplayLayout(false);
+    updateDistanceReadout();
+  }
+
+  function startPlaySession() {
+    window.setGameplayLayout(true);
+    window.settings.energy = Math.max(0, window.settings.energy - 1);
+    window.setHUD();
+    preparePlayRound(true);
+  }
+
+  function updateTargeting(dt) {
+    if (window.world.castStage !== 'aiming') return;
+    const target = window.world.targetCircle;
+    if (!target) return;
+    if (target.holding) {
+      target.holdTime += dt;
+      const desiredSpeed = Math.min(TARGET_SPEED_BASE * (1 + target.holdTime * 0.8), TARGET_SPEED_BASE * 2.2);
+      target.velocity += (desiredSpeed - target.velocity) * (1 - Math.pow(0.001, dt * 9));
+      target.distance += target.velocity * dt;
+      if (target.distance >= TARGET_MAX_DISTANCE) {
+        target.distance = TARGET_MAX_DISTANCE;
+        target.reachedTop = true;
+      }
+      window.world.targetZoom = 1.28;
+    } else {
+      target.velocity += (0 - target.velocity) * (1 - Math.pow(0.001, dt * 12));
+      window.world.targetZoom = 1;
+    }
+    target.distance = window.clamp(target.distance, TARGET_MIN_DISTANCE, TARGET_MAX_DISTANCE);
+    window.world.bobberDist = target.distance;
+    window.world.castDistance = target.distance;
+    updateDistanceReadout();
+  }
+
+  function handlePointerDown() {
+    if (window.state !== window.GameState.Targeting) return;
+    if (window.world.castStage !== 'aiming') return;
+    const target = window.world.targetCircle;
+    if (!target) return;
+    target.holding = true;
+    target.holdTime = 0;
+    target.velocity = 0;
+    target.reachedTop = false;
+    setCastPrompt(false);
+    startCharacterCastAnimation();
+  }
+
+  function clearCatchSimulations() {
+    window.world.pendingCatchSims = [];
+  }
+
+  function beginSinkPhase() {
+    if (window.world.castStage !== 'aiming') return;
+    const target = window.world.targetCircle;
+    if (!target) return;
+    window.world.castStage = 'sinking';
+    window.world.bobberVisible = true;
+    window.world.sinkTimer = 0;
+    window.world.sinkDuration = SINK_DURATION;
+    window.world.sinkStartDist = target.distance;
+    const dropTarget = target.distance - SINK_DISTANCE_DROP;
+    window.world.sinkEndDist = window.clamp(dropTarget, SINK_MIN_DISTANCE, target.distance);
+    window.world.bobberDist = target.distance;
+    window.world.castDistance = target.distance;
+    clearCatchSimulations();
+    window.world.targetCircle = null;
+    setCastPrompt(true, 'Pull!');
+    updateDistanceReadout();
+  }
+
+  function updateCatchSimulations(dt) {
+    if (!Array.isArray(window.world.pendingCatchSims)) {
+      window.world.pendingCatchSims = [];
+    }
+    const sims = window.world.pendingCatchSims;
+    const actives = Array.isArray(window.world.actives) ? window.world.actives : [];
+
+    for (const active of actives) {
+      if (!active || !active.fish) continue;
+      let sim = sims.find(entry => entry.fish === active.fish);
+      if (!sim) {
+        sim = {
+          fish: active.fish,
+          active,
+          successes: 0,
+          failures: 0,
+          timer: window.rand(0, 0.2),
+          interval: window.rand(0.25, 0.55),
+          lastOutcome: null
+        };
+        sims.push(sim);
+      }
+      sim.active = active;
+      sim.timer += dt;
+      while (sim.timer >= sim.interval) {
+        sim.timer -= sim.interval;
+        const success = rollCatch(active);
+        if (success) {
+          sim.successes += 1;
+        } else {
+          sim.failures += 1;
+        }
+        sim.lastOutcome = success;
+        sim.interval = window.rand(0.25, 0.55);
+      }
+    }
+
+    window.world.pendingCatchSims = sims.filter(sim => actives.includes(sim.active));
+  }
+
+  function updateSinkPhase(dt) {
+    if (window.world.castStage !== 'sinking') return;
+    const duration = window.world.sinkDuration || SINK_DURATION;
+    window.world.sinkTimer += dt;
+    const t = window.clamp(duration > 0 ? window.world.sinkTimer / duration : 1, 0, 1);
+    const eased = t * t * (3 - 2 * t);
+    const nextDist = window.lerp(window.world.sinkStartDist, window.world.sinkEndDist, eased);
+    window.world.bobberDist = window.clamp(nextDist, SINK_MIN_DISTANCE, TARGET_MAX_DISTANCE);
+    updateDistanceReadout();
+    updateCatchSimulations(dt);
+    if (window.world.sinkTimer >= duration) {
+      finalizeCatchAttempt();
+    }
+  }
+
+  function finalizeCatchAttempt() {
+    if (window.world.castStage === 'resolved') return;
+    window.world.castStage = 'resolved';
+    setCastPrompt(false);
+    const actives = Array.isArray(window.world.actives) ? window.world.actives.slice() : [];
+    const sims = Array.isArray(window.world.pendingCatchSims) ? window.world.pendingCatchSims : [];
+    const caughtNow = [];
+    let anyActive = false;
+
+    for (const active of actives) {
+      if (!active || !active.fish) continue;
+      anyActive = true;
+      const fish = active.fish;
+      const sim = sims.find(entry => entry.fish === fish) || null;
+      let success = false;
+      if (sim) {
+        const totalChecks = sim.successes + sim.failures;
+        if (totalChecks === 0) {
+          success = rollCatch(active);
+        } else if (sim.successes === sim.failures) {
+          success = sim.lastOutcome ?? rollCatch(active);
+        } else {
+          success = sim.successes > sim.failures;
+        }
+      } else {
+        success = rollCatch(active);
+      }
+
+      if (success) {
+        fish.finished = true;
+        fish.engaged = false;
+        if (fish.active) fish.active = null;
+        caughtNow.push(fish);
+        window.world.catches.push(fish);
+      }
+      releaseActiveCircle(active, false);
+    }
+
+    window.world.actives = [];
+    clearCatchSimulations();
+    window.world.bobberVisible = false;
+
+    if (caughtNow.length) {
+      showResults();
+      return;
+    }
+
+    window.showMissEffect();
+    if (!anyActive) {
+      window.toast('Miss – no fish bit the bobber.');
+    }
+    preparePlayRound(true);
+  }
+
+  function handlePointerUp() {
+    if (window.state !== window.GameState.Targeting) return;
+    if (window.world.castStage !== 'aiming') return;
+    const target = window.world.targetCircle;
+    if (!target || !target.holding) return;
+    target.holding = false;
+    target.velocity = 0;
+    window.world.targetZoom = 1;
+    beginSinkPhase();
+  }
+
+  function showResults() {
+    window.state = window.GameState.Results;
+    window.world.castStage = 'idle';
+    window.world.bobberVisible = false;
+    window.resultsIndex = 0;
+    window.results.style.display = 'flex';
+    if (window.minimap) window.minimap.style.display = 'none';
+    if (window.distanceEl) window.distanceEl.style.display = 'none';
+    window.world.targetCircle = null;
+    setCastPrompt(false);
+    renderResultCard();
+  }
+
+  function renderResultCard() {
+    const count = window.world.catches.length;
+    if (window.resultsIndex >= count) {
+      window.rTitle.textContent = 'All Done!';
+      window.rBody.innerHTML = '<p>Great fishing session!</p>';
+      window.rNext.textContent = 'Continue';
+      return;
+    }
+
+    const fish = window.world.catches[window.resultsIndex];
+    const points = computePoints(fish, window.world.castDistance);
+    window.settings.points += points;
+    window.setHUD();
+
+    window.rTitle.textContent = `Catch ${window.resultsIndex + 1}/${count}`;
+    const escapeHtml = value => String(value ?? '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    const escapeAttr = value => escapeHtml(value).replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+    const fishImages = fish.spec?.images || {};
+    const accentColor = escapeAttr(fish.spec?.ui?.mapColorHex || '#6fffe9');
+    const imageSrc = (fish.image && fish.image.src) || fishImages.card || fishImages.illustration || fishImages.sprite || '';
+    const altText = fish.spec?.displayName ? `${fish.spec.displayName} illustration` : 'Caught fish illustration';
+    const safeAlt = escapeAttr(altText);
+    const safeName = escapeHtml(fish.spec.displayName || 'Mystery Fish');
+    const safeRarity = escapeHtml(fish.spec.rarity || 'Unknown');
+    const visual = imageSrc
+      ? `<img src="${escapeAttr(imageSrc)}" alt="${safeAlt}" loading="lazy" />`
+      : '<div class="placeholder" aria-hidden="true"></div>';
+
+    window.rBody.innerHTML = `
+      <div class="catch-visual">
+        ${visual}
+        <div>
+          <h4 style="color: ${accentColor}; margin-bottom: 10px;">${safeName}</h4>
+          <p><strong>Size:</strong> ${fish.size_cm.toFixed(1)} cm</p>
+          <p><strong>Weight:</strong> ${fish.weight_kg.toFixed(2)} kg</p>
+          <p><strong>Rarity:</strong> ${safeRarity}</p>
+          <p><strong>Points:</strong> ${points}</p>
+        </div>
+      </div>
+    `;
+    window.rNext.textContent = window.resultsIndex < count - 1 ? 'Next' : 'Continue';
+  }
+
+  function awardRemainingCatchPoints() {
+    if (!Array.isArray(window.world.catches) || !window.world.catches.length) return;
+    let bonus = 0;
+    for (let i = window.resultsIndex + 1; i < window.world.catches.length; i++) {
+      const fish = window.world.catches[i];
+      if (!fish) continue;
+      const points = computePoints(fish, window.world.castDistance);
+      window.settings.points += points;
+      bonus += points;
+    }
+    if (bonus > 0) {
+      window.setHUD();
+    }
+  }
+
+  function closeResultsToContinue() {
+    awardRemainingCatchPoints();
+    if (window.results) window.results.style.display = 'none';
+    window.resultsIndex = 0;
+    preparePlayRound(true);
+  }
+
+  function drawTargetCircle(x, y) {
+    const pulse = 1 + Math.sin(window.globalTime * 4) * 0.08;
+    const radius = 30 * pulse;
+    window.ctx.save();
+    window.ctx.lineWidth = 3;
+    window.ctx.strokeStyle = '#6fffe9';
+    window.ctx.globalAlpha = 0.9;
+    window.ctx.beginPath();
+    window.ctx.arc(x, y, radius, 0, Math.PI * 2);
+    window.ctx.stroke();
+    window.ctx.globalAlpha = 0.25;
+    window.ctx.fillStyle = '#0ea5e980';
+    window.ctx.beginPath();
+    window.ctx.arc(x, y, radius * 0.55, 0, Math.PI * 2);
+    window.ctx.fill();
+    window.ctx.restore();
+  }
+
+  function ensureMinimapStructure() {
+    if (!window.mmbar) return null;
+    if (!window.mmCells) {
+      const existingCells = window.mmbar.querySelector('.mmcells');
+      if (existingCells) {
+        window.mmCells = existingCells;
+      } else {
+        const cells = document.createElement('div');
+        cells.className = 'mmcells';
+        window.mmbar.appendChild(cells);
+        window.mmCells = cells;
+      }
+    }
+    if (!window.mmViewport) {
+      const existingViewport = window.mmbar.querySelector('.mmviewport');
+      if (existingViewport) {
+        window.mmViewport = existingViewport;
+      } else {
+        const viewport = document.createElement('div');
+        viewport.className = 'mmviewport';
+        window.mmbar.appendChild(viewport);
+        window.mmViewport = viewport;
+      }
+    }
+    if (!window.mmIndicator) {
+      const existingIndicator = window.mmbar.querySelector('.mmbobber');
+      if (existingIndicator) {
+        window.mmIndicator = existingIndicator;
+      } else {
+        const indicator = document.createElement('div');
+        indicator.className = 'mmbobber';
+        window.mmbar.appendChild(indicator);
+        window.mmIndicator = indicator;
+      }
+    }
+    return window.mmCells;
+  }
+
+  function clearMinimap(hideContainer = false) {
+    const cells = ensureMinimapStructure();
+    if (cells) cells.innerHTML = '';
+    if (window.mmViewport) window.mmViewport.style.opacity = '0';
+    if (window.mmIndicator) window.mmIndicator.style.opacity = '0';
+    if (hideContainer && window.minimap) {
+      window.minimap.style.display = 'none';
+    }
+  }
+
+  function updateMinimap(metrics = window.latestMetrics) {
+    if (!window.mmbar || !window.minimap) return;
+    const cells = ensureMinimapStructure();
+    if (!cells) return;
+
+    if (window.state !== window.GameState.Targeting) {
+      clearMinimap(true);
+      return;
+    }
+
+    if (!Array.isArray(window.world.fishes) || !window.world.fishes.length) {
+      clearMinimap(true);
+      return;
+    }
+
+    if (window.minimap.style.display !== 'flex') {
+      window.minimap.style.display = 'flex';
+    }
+
+    const minDist = window.MIN_CAST_DISTANCE ?? 0;
+    const maxDist = window.MAX_CAST_DISTANCE ?? (window.settings?.maxCast ?? minDist + 1);
+    const range = Math.max(1, maxDist - minDist);
+    const baseSegmentSize = Math.max(1, window.MINIMAP_SEGMENT_METERS || 5);
+    const targetSegments = Math.max(1, Math.ceil(range / baseSegmentSize));
+    const maxSegments = Math.max(8, window.MINIMAP_SEGMENTS || targetSegments);
+    const segments = Math.max(8, Math.min(maxSegments, targetSegments));
+    const segmentMeters = Math.max(range / segments, 1);
+
+    const rarityEntries = new Array(segments).fill(null);
+    const engagedSegments = new Array(segments).fill(false);
+    const priorityMap = window.RARITY_PRIORITY || {};
+    const colorMap = window.RARITY_COLORS || {};
+
+    for (const fish of window.world.fishes) {
+      if (!fish || fish.finished) continue;
+      const dist = clamp(fish.position?.y ?? fish.distance ?? minDist, minDist, maxDist);
+      const index = Math.min(segments - 1, Math.max(0, Math.floor((dist - minDist) / segmentMeters)));
+      const rarity = fish.spec?.rarity || 'Common';
+      const priority = priorityMap[rarity] ?? 0;
+      const existing = rarityEntries[index];
+      if (!existing || priority > existing.priority) {
+        rarityEntries[index] = { rarity, priority, color: colorMap[rarity] };
+      }
+      if (fish.engaged) engagedSegments[index] = true;
+    }
+
+    cells.innerHTML = '';
+
+    const fragment = document.createDocumentFragment();
+    for (let i = segments - 1; i >= 0; i--) {
+      const cell = document.createElement('div');
+      cell.className = 'mmcell';
+      const entry = rarityEntries[i];
+      if (entry && entry.color) {
+        const color = entry.color;
+        cell.style.background = `linear-gradient(180deg, ${color}cc 0%, ${color}99 100%)`;
+        cell.style.opacity = '1';
+      } else if (entry) {
+        cell.style.background = 'rgba(30, 64, 175, 0.55)';
+        cell.style.opacity = '0.9';
+      } else {
+        cell.style.background = 'rgba(15, 23, 42, 0.7)';
+        cell.style.opacity = '0.45';
+      }
+      if (engagedSegments[i]) {
+        cell.style.boxShadow = 'inset 0 0 6px rgba(111, 255, 233, 0.55)';
+      }
+      fragment.appendChild(cell);
+    }
+    cells.appendChild(fragment);
+
+    const barHeight = window.mmbar.clientHeight || window.minimap.clientHeight;
+    const metricsRef = metrics || window.latestMetrics;
+
+    if (window.mmViewport && barHeight > 0 && metricsRef && window.canvas) {
+      const pxPerMeter = metricsRef.pxPerMeter || (window.canvas.height / Math.max(1, window.settings.maxCast));
+      const farMeters = clamp((metricsRef.waterSurfaceY + window.camera.y) / pxPerMeter, minDist, maxDist);
+      const nearMeters = clamp((metricsRef.waterSurfaceY + window.camera.y - window.canvas.height) / pxPerMeter, minDist, maxDist);
+      const farRatio = clamp((farMeters - minDist) / range, 0, 1);
+      const nearRatio = clamp((nearMeters - minDist) / range, 0, 1);
+      const topPx = (1 - farRatio) * barHeight;
+      const bottomPx = (1 - nearRatio) * barHeight;
+      const top = Math.min(topPx, bottomPx);
+      const bottom = Math.max(topPx, bottomPx);
+      const height = Math.max(6, bottom - top);
+      window.mmViewport.style.top = `${top}px`;
+      window.mmViewport.style.height = `${height}px`;
+      window.mmViewport.style.opacity = '1';
+    } else if (window.mmViewport) {
+      window.mmViewport.style.opacity = '0';
+    }
+
+    if (window.mmIndicator && barHeight > 0 && window.world.bobberVisible) {
+      const bobberMeters = clamp(window.world.bobberDist, minDist, maxDist);
+      const bobberRatio = clamp((bobberMeters - minDist) / range, 0, 1);
+      const pos = (1 - bobberRatio) * barHeight;
+      window.mmIndicator.style.top = `${pos}px`;
+      window.mmIndicator.style.opacity = '1';
+    } else if (window.mmIndicator) {
+      window.mmIndicator.style.opacity = '0';
+    }
+  }
+
+  function render() {
+    if (!window.canvas || !window.ctx) return;
+
+    const W = window.canvas.width;
+    const H = window.canvas.height;
+    const metrics = getEnvironmentMetrics(W, H);
+    window.latestMetrics = metrics;
+    const distancePx = window.world.bobberDist * metrics.pxPerMeter;
+    const bobberWorldY = metrics.waterSurfaceY - distancePx;
+    const bobberScreenY = bobberWorldY + window.camera.y;
+    const bobberX = W * 0.5 + metrics.bobberOffsetX;
+    const lateralScale = (W * 0.82) / (Math.max(1, window.world.lateralLimit || WORLD_HALF_WIDTH) * 2);
+    let targetCircleScreenY = bobberScreenY;
+    if (window.world.targetCircle) {
+      const circlePx = window.world.targetCircle.distance * metrics.pxPerMeter;
+      const circleWorldY = metrics.waterSurfaceY - circlePx;
+      targetCircleScreenY = circleWorldY + window.camera.y;
+    }
+
+    window.ctx.clearRect(0, 0, W, H);
+
+    window.ctx.save();
+    const zoom = window.state === window.GameState.Targeting ? (window.world.viewZoom || 1) : 1;
+    if (Math.abs(zoom - 1) > 0.01) {
+      window.ctx.translate(W / 2, bobberScreenY);
+      window.ctx.scale(zoom, zoom);
+      window.ctx.translate(-W / 2, -bobberScreenY);
+    }
+
+    drawEnvironment(W, H, metrics, window.camera.y);
+    if (window.state === window.GameState.Idle) {
+      drawPassingSchool(W, H, metrics);
+    }
+    drawCharacterSprite(W, H, metrics, window.camera.y);
+
+    if (window.state === window.GameState.Targeting) {
+      const stage = window.world.castStage;
+      if (stage === 'aiming' && window.world.targetCircle) {
+        drawTargetCircle(bobberX, targetCircleScreenY);
+      }
+      if (window.world.bobberVisible) {
+        drawFishingLine(window.rodAnchor.x, window.rodAnchor.y, bobberX, bobberScreenY);
+        drawBobber(bobberX, bobberScreenY);
+      }
+
+      for (const fish of window.world.fishes) {
+        if (!fish || fish.finished) continue;
+        const fishDistPx = (fish.position?.y ?? fish.distance) * metrics.pxPerMeter;
+        const fishWorldY = metrics.waterSurfaceY - fishDistPx;
+        const fishScreenY = fishWorldY + window.camera.y;
+        const fishScreenX = W * 0.5 + (fish.position?.x ?? 0) * lateralScale;
+        if (fishScreenY < -80 || fishScreenY > H + 80 || fishScreenX < -80 || fishScreenX > W + 80) {
+          continue;
+        }
+        const fishImage = window.gameData.resources.fish.get(fish.specId);
+        if (fishImage) {
+          const fishScale = 0.75;
+          const fishW = fishImage.width * fishScale;
+          const fishH = fishImage.height * fishScale;
+          const facingRight = !!fish.facingRight;
+          if (facingRight) {
+            window.ctx.save();
+            window.ctx.translate(fishScreenX, fishScreenY);
+            window.ctx.scale(-1, 1);
+            window.ctx.drawImage(fishImage, -fishW / 2, -fishH / 2, fishW, fishH);
+            window.ctx.restore();
+          } else {
+            window.ctx.drawImage(fishImage, fishScreenX - fishW / 2, fishScreenY - fishH / 2, fishW, fishH);
+          }
+        } else {
+          const fishSize = 10;
+          window.ctx.fillStyle = fish.iconColor;
+          window.ctx.beginPath();
+          window.ctx.ellipse(fishScreenX, fishScreenY, fishSize, fishSize * 0.6, 0, 0, Math.PI * 2);
+          window.ctx.fill();
+          window.ctx.fillStyle = `${fish.iconColor}80`;
+          window.ctx.beginPath();
+          window.ctx.arc(fishScreenX + 2, fishScreenY - 4, 3, 0, Math.PI * 2);
+          window.ctx.fill();
+        }
+        if (fish.engaged) {
+          window.ctx.strokeStyle = fish.iconColor;
+          window.ctx.lineWidth = 2;
+          window.ctx.setLineDash([4, 6]);
+          window.ctx.beginPath();
+          window.ctx.arc(fishScreenX, fishScreenY, 14, 0, Math.PI * 2);
+          window.ctx.stroke();
+          window.ctx.setLineDash([]);
+        }
+      }
+
+      if (window.world.bobberVisible) {
+        const dt = window.world.lastFrameDt ?? 1 / 60;
+        updateActiveCircles(dt, bobberX, bobberScreenY, metrics, window.camera.y);
+      }
+    }
+
+    window.ctx.restore();
+
+    if (window.state === window.GameState.Targeting) {
+      updateDistanceReadout();
+    }
+  }
+
+  function gameLoop(currentTime) {
+    if (typeof gameLoop.lastTime !== 'number') {
+      gameLoop.lastTime = currentTime;
+    }
+    const dt = Math.min((currentTime - gameLoop.lastTime) / 1000, 1 / 30);
+    gameLoop.lastTime = currentTime;
+    window.globalTime += dt;
+    window.world.time += dt;
+    window.world.lastFrameDt = dt;
+
+    updateCharacterAnimation(dt);
+    updateFishSimulation(dt);
+
+    const metrics = getEnvironmentMetrics(window.canvas.width, window.canvas.height);
+    if (window.state === window.GameState.Targeting) {
+      if (window.world.castStage === 'aiming') {
+        updateTargeting(dt);
+      } else if (window.world.castStage === 'sinking') {
+        updateSinkPhase(dt);
+      }
+    }
+    updateCamera(window.world.bobberDist, metrics, dt, window.state);
+
+    const zoomSmooth = 1 - Math.pow(0.001, dt * 6);
+    const targetZoom = window.state === window.GameState.Targeting ? (window.world.targetZoom || 1) : 1;
+    window.world.viewZoom += (targetZoom - window.world.viewZoom) * zoomSmooth;
+    if (!Number.isFinite(window.world.viewZoom)) window.world.viewZoom = 1;
+
+    render();
+    if (window.state === window.GameState.Targeting) {
+      updateMinimap();
+    } else {
+      clearMinimap();
+      if (window.minimap) window.minimap.style.display = 'none';
+    }
+    requestAnimationFrame(gameLoop);
+  }
+
+  function setupEventListeners() {
+    window.startBtn.addEventListener('click', async () => {
+      if (!window.dataLoaded || !window.assetsReady) {
+        window.startBtn.textContent = 'Loading Assets...';
+        window.startBtn.classList.add('disabled');
+        const success = await loadGameData();
+        if (success) {
+          window.startBtn.textContent = 'Game Play';
+          window.startBtn.classList.remove('disabled', 'error');
+        } else {
+          window.startBtn.textContent = 'Failed to Load - Retry';
+          window.startBtn.classList.add('error');
+        }
+        return;
+      }
+      if (window.state !== window.GameState.Idle) return;
+      if (window.settings.energy <= 0) {
+        window.toast('Not enough energy.');
+        return;
+      }
+      startPlaySession();
+    });
+
+    window.canvas.addEventListener('click', () => {
+      if (window.state === window.GameState.Idle && window.dataLoaded && window.assetsReady) {
+        if (window.settings.energy <= 0) {
+          window.toast('Not enough energy.');
+          return;
+        }
+        startPlaySession();
+      }
+    });
+
+    window.addEventListener('pointerdown', handlePointerDown);
+    window.addEventListener('pointerup', handlePointerUp);
+    window.addEventListener('pointercancel', handlePointerUp);
+
+    window.rNext.addEventListener('click', () => {
+      window.resultsIndex++;
+      if (window.resultsIndex < window.world.catches.length) {
+        renderResultCard();
+      } else {
+        closeResultsToContinue();
+      }
+    });
+
+    window.rSkip.addEventListener('click', () => {
+      closeResultsToContinue();
+    });
+
+    const comingSoon = label => () => window.toast(`${label} – Coming Soon`);
+    if (window.shopBtn) window.shopBtn.addEventListener('click', comingSoon('Shop'));
+    if (window.rankBtn) window.rankBtn.addEventListener('click', comingSoon('Ranking'));
+    if (window.premiumBtn) window.premiumBtn.addEventListener('click', comingSoon('Premium Mode'));
+    if (window.exitBtn) {
+      window.exitBtn.addEventListener('click', () => {
+        exitToMenu();
+      });
+    }
+  }
+
+  async function initGame() {
+    ensureDomReferences();
+    resizeCanvas();
+    window.addEventListener('resize', resizeCanvas);
+    window.state = window.GameState.Idle;
+    window.resultsIndex = 0;
+    window.setGameplayLayout(false);
+    window.setHUD();
+
+    const success = await loadGameData();
+    if (success) {
+      window.startBtn.textContent = 'Game Play';
+      window.startBtn.classList.remove('disabled');
+      window.setHUD();
+    }
+
+    setupEventListeners();
+    requestAnimationFrame(gameLoop);
+    setInterval(() => {
+      if (window.settings.energy < 10) {
+        window.settings.energy++;
+        window.setHUD();
+      }
+    }, 30000);
+  }
+
+  document.addEventListener('DOMContentLoaded', () => {
+    initGame().catch(err => console.error(err));
+  });
+})();
+

--- a/js/rendering.js
+++ b/js/rendering.js
@@ -126,7 +126,7 @@ function updateCharacterAnimation(dt) {
     sprite.playing = false;
     const hold = sprite.holdFrame ?? sprite.postCastFrame;
     if (typeof hold === 'number') sprite.currentFrame = hold;
-  } else if (state === GameState.Idle || state === GameState.Casting) {
+  } else if (state === GameState.Idle || state === GameState.Targeting) {
     sprite.currentFrame = sprite.idleFrame || 0;
   }
 }
@@ -191,7 +191,7 @@ function updateCamera(distance, metrics, dt, state) {
   const distancePx = clamp(distance * metrics.pxPerMeter, 0, metrics.distancePxRange);
   const baseY = metrics.waterSurfaceY - distancePx;
   let desired = 0;
-  if (state === GameState.Flight || state === GameState.Fishing) {
+  if (state === GameState.Targeting) {
     desired = clamp(metrics.targetBobberY - baseY, 0, metrics.maxScroll);
   }
   const smoothing = 1 - Math.pow(0.001, dt * 9);

--- a/js/state.js
+++ b/js/state.js
@@ -1,0 +1,178 @@
+// Global game state and configuration values.
+// These are attached to the window object so that the individual script files
+// can share the same state without relying on implicit hoisting of "var".
+
+window.DATA_URL = './data/fish.json';
+
+window.MIN_CAST_DISTANCE = 30;
+window.MAX_CAST_DISTANCE = 200;
+window.MIN_SINK_DISTANCE = 24;
+
+window.GameState = {
+  Idle: 'Idle',
+  Targeting: 'Targeting',
+  Results: 'Results'
+};
+
+window.RARITY_WEIGHTS = {
+  Common: 100,
+  Uncommon: 50,
+  Rare: 20,
+  Epic: 8,
+  Legendary: 3,
+  Mythic: 1
+};
+
+window.RARITY_PRIORITY = {
+  Common: 0,
+  Uncommon: 1,
+  Rare: 2,
+  Epic: 3,
+  Legendary: 4,
+  Mythic: 5
+};
+
+window.RARITY_COLORS = {
+  Common: '#1d4ed8',
+  Uncommon: '#10b981',
+  Rare: '#8b5cf6',
+  Epic: '#f97316',
+  Legendary: '#facc15',
+  Mythic: '#f472b6'
+};
+
+window.FISH_SWIM_SPEED_TABLE = {
+  Fast: 8,
+  Normal: 5,
+  Slow: 3
+};
+
+window.DETECTION_RANGE_M = 5;
+window.FISH_SCHOOLING_RADIUS = 18;
+window.FISH_AVOIDANCE_RADIUS = 12;
+window.FISH_AVOIDANCE_FORCE = 6;
+window.FISH_SEPARATION_FORCE = 0.9;
+window.FISH_COHESION_FORCE = 0.65;
+window.FISH_ALIGNMENT_FORCE = 0.45;
+window.FISH_WANDER_FORCE = 0.55;
+window.FISH_CENTERING_FORCE = 0.35;
+window.MINIMAP_SEGMENTS = 48;
+window.MINIMAP_SEGMENT_METERS = 5;
+
+window.loadingPromise = null;
+window.assetPrepPromise = null;
+window.dataLoaded = false;
+window.assetsReady = false;
+window.passingSchool = [];
+window.passingSchoolMode = 'title';
+window.state = window.GameState?.Idle ?? 'Idle';
+window.resultsIndex = 0;
+
+window.canvas = null;
+window.ctx = null;
+window.startBtn = null;
+window.mainMenu = null;
+window.titleBar = null;
+window.navBar = null;
+window.exitBtn = null;
+window.shopBtn = null;
+window.rankBtn = null;
+window.premiumBtn = null;
+window.toastEl = null;
+window.missEffect = null;
+window.distanceEl = null;
+window.minimap = null;
+window.mmbar = null;
+window.mmCells = null;
+window.mmViewport = null;
+window.mmIndicator = null;
+window.results = null;
+window.rTitle = null;
+window.rBody = null;
+window.rNext = null;
+window.rSkip = null;
+window.energyEl = null;
+window.pointsEl = null;
+window.castPrompt = null;
+
+window.gameData = {
+  assets: {},
+  species: [],
+  characters: [],
+  environment: null,
+  player: null,
+  resources: {
+    fish: new Map(),
+    icons: {}
+  }
+};
+
+window.SPECIES = window.gameData.species;
+window.CHARACTERS = window.gameData.characters;
+
+window.settings = {
+  energy: 10,
+  points: 0,
+  baseCast: 30,
+  maxCast: 200,
+  rodTier: 1,
+  lineTier: 1
+};
+
+window.world = {
+  castDistance: 0,
+  bobberDist: 0,
+  castStage: 'idle',
+  bobberVisible: false,
+  fishes: [],
+  actives: [],
+  catches: [],
+  time: 0,
+  lateralLimit: 5,
+  displayRange: 5,
+  targetCircle: null,
+  viewZoom: 1,
+  targetZoom: 1,
+  sinkTimer: 0,
+  sinkDuration: 0,
+  sinkStartDist: 0,
+  sinkEndDist: 0,
+  pendingCatchSims: []
+};
+
+window.camera = { y: 0 };
+window.rodAnchor = { x: 0, y: 0 };
+window.baseX = 0;
+
+window.environmentState = {
+  tileWidth: 40,
+  tileHeight: 40,
+  landRows: 3,
+  sources: {},
+  water: null,
+  shore: null,
+  land: null
+};
+
+window.characterSprite = {
+  image: null,
+  spriteSource: null,
+  frameWidth: 40,
+  frameHeight: 40,
+  frameCount: 4,
+  currentFrame: 0,
+  idleFrame: 0,
+  postCastFrame: 3,
+  castSequence: [0, 1, 2, 3],
+  frameDuration: 0.12,
+  scale: 2.4,
+  lineAnchor: { x: 30, y: 18 },
+  playing: false,
+  animationIndex: 0,
+  timer: 0,
+  holdFrame: 3
+};
+
+window.globalTime = 0;
+window.latestMetrics = null;
+

--- a/js/utils.js
+++ b/js/utils.js
@@ -1,0 +1,98 @@
+// Shared utility helpers used across the game scripts.
+
+window.clamp = function clamp(value, min, max) {
+  if (value < min) return min;
+  if (value > max) return max;
+  return value;
+};
+
+window.lerp = function lerp(a, b, t) {
+  return a + (b - a) * t;
+};
+
+window.rand = function rand(min, max) {
+  return Math.random() * (max - min) + min;
+};
+
+window.randi = function randi(min, max) {
+  return Math.floor(Math.random() * (max - min + 1)) + min;
+};
+
+window.pick = function pick(list) {
+  if (!Array.isArray(list) || list.length === 0) return null;
+  const index = Math.floor(Math.random() * list.length);
+  return list[index];
+};
+
+window.loadImage = function loadImage(src) {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => resolve(img);
+    img.onerror = () => reject(new Error(`Failed to load image: ${src}`));
+    img.src = src;
+  });
+};
+
+window.getCssVar = function getCssVar(name) {
+  return getComputedStyle(document.documentElement).getPropertyValue(name) || '';
+};
+
+window.toast = function toast(message) {
+  const target = window.toastEl;
+  if (!target) {
+    console.warn('Toast element missing:', message);
+    return;
+  }
+  target.textContent = message;
+  target.classList.add('show');
+  clearTimeout(target._hideTimer);
+  target._hideTimer = setTimeout(() => target.classList.remove('show'), 2000);
+};
+
+window.showMissEffect = function showMissEffect() {
+  if (!window.missEffect) return;
+  window.missEffect.classList.remove('show');
+  void window.missEffect.offsetWidth;
+  window.missEffect.classList.add('show');
+  clearTimeout(window.missEffect._hideTimer);
+  window.missEffect._hideTimer = setTimeout(() => window.missEffect.classList.remove('show'), 500);
+};
+
+window.setHUD = function setHUD() {
+  if (window.energyEl) window.energyEl.textContent = window.settings.energy;
+  if (window.pointsEl) window.pointsEl.textContent = window.settings.points;
+};
+
+window.setGameplayLayout = function setGameplayLayout(active) {
+  const container = document.getElementById('game');
+  if (container) container.classList.toggle('gameplay', !!active);
+
+  if (window.canvas) {
+    window.canvas.style.cursor = active ? 'crosshair' : 'default';
+  }
+
+  if (window.distanceEl) {
+    window.distanceEl.style.display = active ? 'block' : 'none';
+  }
+
+  if (!active && window.minimap) {
+    window.minimap.style.display = 'none';
+  }
+
+  if (window.mainMenu) {
+    window.mainMenu.setAttribute('aria-hidden', active ? 'true' : 'false');
+  }
+
+  if (window.navBar) {
+    window.navBar.setAttribute('aria-hidden', active ? 'true' : 'false');
+    window.navBar.querySelectorAll('button').forEach(btn => {
+      btn.tabIndex = active ? -1 : 0;
+    });
+  }
+
+  if (window.exitBtn) {
+    window.exitBtn.setAttribute('aria-hidden', active ? 'false' : 'true');
+    window.exitBtn.tabIndex = active ? 0 : -1;
+  }
+};
+


### PR DESCRIPTION
## Summary
- shrink the minimap, keep it hidden outside gameplay, and recolor its segments based on highest rarity present
- reposition the version tag to the bottom-center of the menu screen while keeping it out of the play view
- spread fish uniformly across 30–200 m with slower swim speeds to match the new rarity-focused minimap cues

## Testing
- Not run (no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68d4ad1bbdf4832ab9d4902e800956dc