### PR TITLE
Implement reel battle fishing mini-game

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,6 +69,38 @@
       font-size: 14px;
       font-weight: 600;
       backdrop-filter: blur(10px);
+      position: relative;
+      overflow: hidden;
+    }
+
+    .pill.sparkle {
+      animation: sparkleFlash 0.9s ease-out;
+      box-shadow: 0 0 24px rgba(111, 255, 233, 0.45);
+    }
+
+    .pill.sparkle::after {
+      content: '';
+      position: absolute;
+      top: -40%;
+      left: -30%;
+      width: 40%;
+      height: 180%;
+      background: linear-gradient(120deg, rgba(111, 255, 233, 0), rgba(255, 255, 255, 0.75), rgba(111, 255, 233, 0));
+      transform: rotate(25deg);
+      animation: sparkleSweep 0.9s ease-out;
+      pointer-events: none;
+    }
+
+    @keyframes sparkleFlash {
+      0% { transform: scale(1); box-shadow: 0 0 0 rgba(111, 255, 233, 0.1); }
+      40% { transform: scale(1.05); box-shadow: 0 0 28px rgba(111, 255, 233, 0.55); }
+      100% { transform: scale(1); box-shadow: 0 0 12px rgba(111, 255, 233, 0.2); }
+    }
+
+    @keyframes sparkleSweep {
+      0% { transform: translateX(0) rotate(25deg); opacity: 0; }
+      40% { opacity: 1; }
+      100% { transform: translateX(220%) rotate(25deg); opacity: 0; }
     }
 
     #titleBar {
@@ -440,6 +472,172 @@
       backdrop-filter: blur(10px);
     }
 
+    .battle-modal .battle-card,
+    .battle-summary .battle-summary-card {
+      background: linear-gradient(160deg, rgba(28, 37, 65, 0.95), rgba(15, 23, 42, 0.92));
+      border: 1px solid rgba(111, 255, 233, 0.18);
+      box-shadow: 0 18px 40px rgba(2, 8, 23, 0.65);
+      padding: 28px 26px;
+      border-radius: 22px;
+      width: min(420px, 92vw);
+      color: var(--text);
+      position: relative;
+      overflow: hidden;
+    }
+
+    .battle-card h3 {
+      font-size: 1.6rem;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      margin-bottom: 22px;
+    }
+
+    .battle-gauge {
+      margin: 0 auto 22px;
+      width: 100%;
+      max-width: 320px;
+    }
+
+    .gauge-track {
+      position: relative;
+      width: 100%;
+      height: 26px;
+      border-radius: 18px;
+      overflow: hidden;
+      background: rgba(148, 163, 184, 0.25);
+      border: 1px solid rgba(111, 255, 233, 0.25);
+    }
+
+    .gauge-white {
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      background: linear-gradient(90deg, rgba(255,255,255,0.85), rgba(241,245,249,0.6));
+      border-radius: 18px;
+    }
+
+    .gauge-red {
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      left: 50%;
+      transform: translateX(-50%);
+      width: 22%;
+      background: linear-gradient(90deg, rgba(248, 113, 113, 0.92), rgba(239, 68, 68, 0.92));
+      box-shadow: inset 0 0 15px rgba(127, 29, 29, 0.6);
+    }
+
+    .gauge-fish {
+      position: absolute;
+      top: 50%;
+      width: 16px;
+      height: 16px;
+      background: #111827;
+      border-radius: 8px;
+      transform: translate(-50%, -50%);
+      box-shadow: 0 0 12px rgba(0, 0, 0, 0.45);
+    }
+
+    .battle-fish {
+      position: relative;
+      height: 140px;
+      margin-bottom: 16px;
+    }
+
+    .battle-fish-image {
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      transition: transform 0.5s ease, filter 0.5s ease;
+      max-width: 220px;
+    }
+
+    .battle-fish-image img,
+    .battle-fish-image .placeholder {
+      display: block;
+      width: 100%;
+      height: auto;
+      filter: drop-shadow(0 16px 25px rgba(0, 0, 0, 0.45));
+    }
+
+    .battle-fish-image .placeholder {
+      width: 180px;
+      height: 64px;
+      border-radius: 18px;
+      background: rgba(30, 64, 175, 0.25);
+      border: 1px dashed rgba(148, 163, 184, 0.4);
+    }
+
+    .battle-fish-image.celebrate {
+      transform: translate(-50%, -50%) scale(1.2);
+      filter: drop-shadow(0 0 24px rgba(111, 255, 233, 0.55));
+    }
+
+    .battle-status {
+      font-size: 1.2rem;
+      font-weight: 700;
+      letter-spacing: 0.04em;
+      min-height: 1.4em;
+      margin-bottom: 12px;
+      text-align: center;
+    }
+
+    .battle-status.success { color: var(--success); }
+    .battle-status.fail { color: var(--error); }
+
+    .battle-info {
+      text-align: center;
+      font-size: 0.95rem;
+      line-height: 1.5;
+      color: var(--text-dim);
+      min-height: 60px;
+    }
+
+    .battle-info strong { color: var(--secondary); }
+
+    .battle-actions {
+      display: flex;
+      justify-content: center;
+      margin-top: 22px;
+    }
+
+    .battle-actions .btn { min-width: 140px; }
+
+    .battle-actions .btn.disabled {
+      pointer-events: none;
+      opacity: 0.5;
+    }
+
+    .battle-summary-card h3 {
+      font-size: 1.5rem;
+      margin-bottom: 18px;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+    }
+
+    .battle-summary-list {
+      max-height: 220px;
+      overflow-y: auto;
+      margin-bottom: 18px;
+      padding-right: 6px;
+    }
+
+    .battle-summary-list p {
+      font-size: 0.95rem;
+      margin-bottom: 8px;
+      display: flex;
+      justify-content: space-between;
+      gap: 12px;
+    }
+
+    .battle-summary-total {
+      font-weight: 700;
+      font-size: 1.1rem;
+      text-align: center;
+      margin-bottom: 18px;
+    }
+
     .card {
       background: var(--bg-light);
       padding: 30px;
@@ -565,6 +763,38 @@
         <div class="actions">
           <div class="btn" id="rSkip">Skip</div>
           <div class="btn primary" id="rNext">Next</div>
+        </div>
+      </div>
+    </div>
+
+    <div class="modal battle-modal" id="reelBattleModal" aria-hidden="true">
+      <div class="battle-card">
+        <h3>Reel battle</h3>
+        <div class="battle-gauge">
+          <div class="gauge-track">
+            <div class="gauge-white" id="battleGaugeWhite"></div>
+            <div class="gauge-red"></div>
+            <div class="gauge-fish" id="battleGaugeFish"></div>
+          </div>
+        </div>
+        <div class="battle-fish">
+          <div class="battle-fish-image" id="battleFishImage"></div>
+        </div>
+        <div class="battle-status" id="battleStatus"></div>
+        <div class="battle-info" id="battleInfo"></div>
+        <div class="battle-actions">
+          <button class="btn primary" id="battleNext" type="button">Next</button>
+        </div>
+      </div>
+    </div>
+
+    <div class="modal battle-summary" id="catchSummary" aria-hidden="true">
+      <div class="battle-summary-card">
+        <h3>Catch Summary</h3>
+        <div class="battle-summary-list" id="summaryList"></div>
+        <div class="battle-summary-total">Total Point: <span id="summaryTotal">0</span></div>
+        <div class="battle-actions">
+          <button class="btn primary" id="summaryClose" type="button">Close</button>
         </div>
       </div>
     </div>

--- a/js/main.js
+++ b/js/main.js
@@ -2,6 +2,28 @@
 // Relies on global state defined in state.js and helpers from utils.js.
 
 (function () {
+  const reelBattle = {
+    modal: null,
+    white: null,
+    marker: null,
+    fishImage: null,
+    status: null,
+    info: null,
+    nextBtn: null,
+    summaryModal: null,
+    summaryList: null,
+    summaryTotal: null,
+    summaryClose: null,
+    queue: [],
+    index: -1,
+    results: [],
+    state: null,
+    totalPoints: 0,
+    redWidth: 0.22,
+    finalWhite: 0.22,
+    duration: 4.2
+  };
+
   function ensureDomReferences() {
     window.canvas = document.getElementById('view');
     window.ctx = window.canvas?.getContext('2d') ?? null;
@@ -29,6 +51,17 @@
     window.rSkip = document.getElementById('rSkip');
     window.energyEl = document.getElementById('energy');
     window.pointsEl = document.getElementById('points');
+    reelBattle.modal = document.getElementById('reelBattleModal');
+    reelBattle.white = document.getElementById('battleGaugeWhite');
+    reelBattle.marker = document.getElementById('battleGaugeFish');
+    reelBattle.fishImage = document.getElementById('battleFishImage');
+    reelBattle.status = document.getElementById('battleStatus');
+    reelBattle.info = document.getElementById('battleInfo');
+    reelBattle.nextBtn = document.getElementById('battleNext');
+    reelBattle.summaryModal = document.getElementById('catchSummary');
+    reelBattle.summaryList = document.getElementById('summaryList');
+    reelBattle.summaryTotal = document.getElementById('summaryTotal');
+    reelBattle.summaryClose = document.getElementById('summaryClose');
 
     if (!window.canvas || !window.ctx || !window.startBtn || !window.mainMenu) {
       throw new Error('Essential DOM elements are missing.');
@@ -297,6 +330,368 @@
     window.castPrompt.classList.toggle('show', !!visible);
   }
 
+  function escapeHtml(value) {
+    return String(value ?? '')
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
+  function setModalVisibility(element, visible) {
+    if (!element) return;
+    element.style.display = visible ? 'flex' : 'none';
+    element.setAttribute('aria-hidden', visible ? 'false' : 'true');
+  }
+
+  function resetReelBattle(hideModals = true) {
+    reelBattle.queue = [];
+    reelBattle.index = -1;
+    reelBattle.results = [];
+    reelBattle.state = null;
+    reelBattle.totalPoints = 0;
+    window.world.battleQueue = [];
+    window.world.battleResults = [];
+    window.world.currentBattleIndex = -1;
+    window.world.pendingPointTotal = 0;
+    if (hideModals) {
+      setModalVisibility(reelBattle.modal, false);
+      setModalVisibility(reelBattle.summaryModal, false);
+    }
+    if (reelBattle.status) {
+      reelBattle.status.textContent = '';
+      reelBattle.status.classList.remove('success', 'fail');
+    }
+    if (reelBattle.info) {
+      reelBattle.info.textContent = '';
+    }
+    if (reelBattle.fishImage) {
+      reelBattle.fishImage.innerHTML = '';
+      reelBattle.fishImage.classList.remove('celebrate');
+      reelBattle.fishImage.style.transform = '';
+    }
+    if (reelBattle.white) {
+      reelBattle.white.style.left = '0%';
+      reelBattle.white.style.width = '100%';
+    }
+    if (reelBattle.marker) {
+      reelBattle.marker.style.left = '50%';
+    }
+    if (reelBattle.nextBtn) {
+      reelBattle.nextBtn.disabled = true;
+      reelBattle.nextBtn.classList.add('disabled');
+    }
+  }
+
+  function renderBattleFishArt(fish) {
+    if (!reelBattle.fishImage) return;
+    const container = reelBattle.fishImage;
+    container.innerHTML = '';
+    container.classList.remove('celebrate');
+    container.style.transform = 'translate(-50%, -50%)';
+    if (!fish) {
+      const placeholder = document.createElement('div');
+      placeholder.className = 'placeholder';
+      container.appendChild(placeholder);
+      return;
+    }
+    const images = fish.spec?.images || {};
+    const cache = window.gameData?.resources?.fish;
+    const cachedImg = fish.image || cache?.get?.(fish.specId) || null;
+    const src = cachedImg?.src || images.card || images.illustration || images.sprite || '';
+    if (src) {
+      const img = document.createElement('img');
+      img.src = src;
+      img.alt = `${fish.spec?.displayName || 'Fish'} illustration`;
+      container.appendChild(img);
+    } else {
+      const placeholder = document.createElement('div');
+      placeholder.className = 'placeholder';
+      container.appendChild(placeholder);
+    }
+  }
+
+  function gatherFishCandidates(range) {
+    const fishes = [];
+    if (!Array.isArray(window.world.fishes)) return fishes;
+    for (const fish of window.world.fishes) {
+      if (!fish || fish.finished) continue;
+      const x = fish.position?.x ?? 0;
+      const y = fish.position?.y ?? fish.distance ?? window.world.bobberDist;
+      const dy = y - window.world.bobberDist;
+      const dist = Math.sqrt(x * x + dy * dy);
+      if (!Number.isFinite(dist)) continue;
+      if (dist <= range) {
+        fishes.push({ fish, dist });
+      }
+    }
+    fishes.sort((a, b) => a.dist - b.dist);
+    return fishes.map(entry => entry.fish);
+  }
+
+  function computeBattleChance(fish, candidateCount) {
+    const spec = fish?.spec || {};
+    let base = 0.55;
+    const rarityAdjust = {
+      Common: 0.12,
+      Uncommon: 0.05,
+      Rare: -0.02,
+      Epic: -0.08,
+      Legendary: -0.15,
+      Mythic: -0.2
+    }[spec.rarity] ?? 0;
+    base += rarityAdjust;
+    const stressFactor = window.clamp(1 - (fish?.stressLevel ?? 0) * 0.35, 0.7, 1.1);
+    base *= stressFactor;
+    const crowding = window.clamp(0.12 - (candidateCount - 1) * 0.04, -0.12, 0.18);
+    base += crowding;
+    if (fish?.bonusMultiplier > 1) {
+      base += 0.04 * (fish.bonusMultiplier - 1);
+    }
+    return window.clamp(base, 0.1, 0.92);
+  }
+
+  function startReelBattleSequence(fishes) {
+    if (!Array.isArray(fishes) || !fishes.length) return;
+    window.state = window.GameState.Results;
+    window.world.castStage = 'idle';
+    window.world.bobberVisible = false;
+    resetReelBattle(false);
+    reelBattle.queue = fishes.map(fish => {
+      const chance = computeBattleChance(fish, fishes.length);
+      return {
+        fish,
+        chance,
+        success: Math.random() < chance,
+        resolved: false,
+        points: 0
+      };
+    });
+    reelBattle.index = -1;
+    reelBattle.results = [];
+    reelBattle.totalPoints = 0;
+    reelBattle.state = null;
+    window.world.battleQueue = reelBattle.queue.map(entry => entry.fish);
+    window.world.battleResults = reelBattle.results;
+    window.world.currentBattleIndex = -1;
+    window.world.pendingPointTotal = 0;
+    if (window.results) window.results.style.display = 'none';
+    if (window.minimap) window.minimap.style.display = 'none';
+    if (window.distanceEl) window.distanceEl.style.display = 'none';
+    setCastPrompt(false);
+    beginNextReelBattle();
+  }
+
+  function beginNextReelBattle() {
+    reelBattle.index += 1;
+    window.world.currentBattleIndex = reelBattle.index;
+    if (reelBattle.index >= reelBattle.queue.length) {
+      finishReelBattleSequence();
+      return;
+    }
+    setupReelBattle(reelBattle.queue[reelBattle.index]);
+  }
+
+  function setupReelBattle(candidate) {
+    if (!candidate || !candidate.fish) {
+      beginNextReelBattle();
+      return;
+    }
+    const fish = candidate.fish;
+    if (reelBattle.status) {
+      reelBattle.status.textContent = '줄을 잡아당기는 중...';
+      reelBattle.status.classList.remove('success', 'fail');
+    }
+    if (reelBattle.info) {
+      const name = fish.spec?.displayName || '알 수 없는 물고기';
+      reelBattle.info.textContent = `${name}이(가) 버티고 있습니다.`;
+    }
+    renderBattleFishArt(fish);
+    if (reelBattle.white) {
+      reelBattle.white.style.left = '0%';
+      reelBattle.white.style.width = '100%';
+    }
+    if (reelBattle.marker) {
+      reelBattle.marker.style.left = '50%';
+    }
+    if (reelBattle.nextBtn) {
+      reelBattle.nextBtn.disabled = true;
+      reelBattle.nextBtn.classList.add('disabled');
+      reelBattle.nextBtn.textContent = 'Next';
+    }
+    setModalVisibility(reelBattle.modal, true);
+    reelBattle.state = {
+      candidate,
+      elapsed: 0,
+      duration: reelBattle.duration,
+      redWidth: reelBattle.redWidth,
+      finalWhite: reelBattle.finalWhite,
+      currentWidth: 1,
+      fishPos: 0.5,
+      fishPhase: Math.random() * Math.PI * 2,
+      fishSpeed: 3 + Math.random() * 1.8,
+      success: candidate.success,
+      resolved: false,
+      failTriggered: false,
+      failDirection: Math.random() > 0.5 ? 1 : -1
+    };
+  }
+
+  function resolveReelBattleOutcome(success) {
+    const state = reelBattle.state;
+    if (!state || state.resolved) return;
+    state.resolved = true;
+    const candidate = state.candidate;
+    candidate.resolved = true;
+    candidate.outcome = success;
+    const fish = candidate.fish;
+    const name = fish.spec?.displayName || 'Mystery Fish';
+    const rarity = fish.spec?.rarity || 'Unknown';
+    fish.finished = true;
+    if (reelBattle.status) {
+      reelBattle.status.textContent = success ? '성공' : '실패';
+      reelBattle.status.classList.toggle('success', success);
+      reelBattle.status.classList.toggle('fail', !success);
+    }
+    let infoHtml = '';
+    if (success) {
+      if (reelBattle.fishImage) reelBattle.fishImage.classList.add('celebrate');
+      const points = computePoints(fish, window.world.castDistance);
+      candidate.points = points;
+      reelBattle.totalPoints += points;
+      window.world.pendingPointTotal = reelBattle.totalPoints;
+      reelBattle.results.push({ fish, success: true, points });
+      if (!window.world.catches.includes(fish)) {
+        window.world.catches.push(fish);
+      }
+      infoHtml = `
+        <p><strong>${escapeHtml(name)}</strong> (${escapeHtml(rarity)})</p>
+        <p>Size: ${fish.size_cm.toFixed(1)} cm · Weight: ${fish.weight_kg.toFixed(2)} kg</p>
+        <p><strong>Points +${points}</strong></p>
+      `;
+    } else {
+      candidate.points = 0;
+      reelBattle.results.push({ fish, success: false, points: 0 });
+      infoHtml = `
+        <p><strong>${escapeHtml(name)}</strong> (${escapeHtml(rarity)})</p>
+        <p>Size: ${fish.size_cm.toFixed(1)} cm · Weight: ${fish.weight_kg.toFixed(2)} kg</p>
+        <p><strong>Points +0</strong></p>
+        <p style="margin-top:6px;">도망가 버렸어요!</p>
+      `;
+    }
+    if (reelBattle.info) {
+      reelBattle.info.innerHTML = infoHtml;
+    }
+    if (reelBattle.nextBtn) {
+      reelBattle.nextBtn.disabled = false;
+      reelBattle.nextBtn.classList.remove('disabled');
+    }
+  }
+
+  function updateReelBattle(dt) {
+    const state = reelBattle.state;
+    if (!state || !reelBattle.modal || reelBattle.summaryModal?.style.display === 'flex') return;
+    state.elapsed = Math.min(state.elapsed + dt, state.duration + 0.6);
+    const t = window.clamp(state.elapsed / state.duration, 0, 1);
+    const eased = t * t * (3 - 2 * t);
+    const currentWidth = window.lerp(1, state.finalWhite, eased);
+    state.currentWidth = currentWidth;
+    const whiteLeft = 0.5 - currentWidth / 2;
+    if (reelBattle.white) {
+      reelBattle.white.style.left = `${whiteLeft * 100}%`;
+      reelBattle.white.style.width = `${currentWidth * 100}%`;
+    }
+    state.fishPhase += dt * state.fishSpeed;
+    const safeAmplitude = Math.max(0.02, currentWidth / 2 - state.redWidth / 2 - 0.01);
+    if (state.success) {
+      const amp = Math.max(0.02, safeAmplitude);
+      state.fishPos = 0.5 + Math.sin(state.fishPhase) * amp;
+      state.fishPos = window.clamp(state.fishPos, whiteLeft + 0.02, whiteLeft + currentWidth - 0.02);
+    } else {
+      if (!state.failTriggered && state.elapsed > state.duration * 0.55) {
+        state.failTriggered = true;
+      }
+      if (state.failTriggered) {
+        state.fishPos += state.failDirection * dt * 0.35;
+      } else {
+        const amp = Math.max(0.02, safeAmplitude * 0.8);
+        state.fishPos = 0.5 + Math.sin(state.fishPhase) * amp;
+      }
+    }
+    const trackWidth = reelBattle.white?.parentElement?.clientWidth || 0;
+    if (reelBattle.marker) {
+      reelBattle.marker.style.left = `${state.fishPos * 100}%`;
+    }
+    if (reelBattle.fishImage && trackWidth) {
+      const offset = (state.fishPos - 0.5) * trackWidth;
+      reelBattle.fishImage.style.transform = `translate(-50%, -50%) translateX(${offset}px)`;
+    }
+    const whiteRight = whiteLeft + currentWidth;
+    const redLeft = 0.5 - state.redWidth / 2;
+    const redRight = 0.5 + state.redWidth / 2;
+    if (!state.resolved) {
+      if (state.success && currentWidth <= state.redWidth + 0.001) {
+        if (state.fishPos >= redLeft && state.fishPos <= redRight) {
+          resolveReelBattleOutcome(true);
+        }
+      }
+      if (!state.success && (state.fishPos < whiteLeft || state.fishPos > whiteRight)) {
+        resolveReelBattleOutcome(false);
+      }
+      if (state.elapsed >= state.duration + 0.5 && !state.resolved) {
+        resolveReelBattleOutcome(state.success);
+      }
+    }
+  }
+
+  function finishReelBattleSequence() {
+    reelBattle.state = null;
+    setModalVisibility(reelBattle.modal, false);
+    showCatchSummary();
+  }
+
+  function showCatchSummary() {
+    if (!reelBattle.summaryModal) {
+      preparePlayRound(true);
+      return;
+    }
+    const list = reelBattle.summaryList;
+    if (list) {
+      if (!reelBattle.results.length) {
+        list.innerHTML = '<p>아무 것도 잡지 못했습니다.</p>';
+      } else {
+        list.innerHTML = reelBattle.results
+          .map((result, index) => {
+            const fish = result.fish;
+            const name = escapeHtml(fish.spec?.displayName || `Catch ${index + 1}`);
+            const rarity = escapeHtml(fish.spec?.rarity || 'Unknown');
+            const points = result.points;
+            const label = result.success ? `+${points}` : '+0';
+            const status = result.success ? '성공' : '실패';
+            return `<p><span>${index + 1}. ${name} (${rarity}) – ${status}</span><span>${label}</span></p>`;
+          })
+          .join('');
+      }
+    }
+    if (reelBattle.summaryTotal) {
+      reelBattle.summaryTotal.textContent = reelBattle.totalPoints.toLocaleString();
+    }
+    setModalVisibility(reelBattle.summaryModal, true);
+  }
+
+  function closeCatchSummary() {
+    const total = reelBattle.totalPoints;
+    setModalVisibility(reelBattle.summaryModal, false);
+    if (total > 0) {
+      window.addPointsWithSparkle(total);
+    } else {
+      window.setHUD();
+    }
+    resetReelBattle();
+    preparePlayRound(true);
+  }
+
   function resetTargetCircle() {
     window.world.targetCircle = {
       distance: TARGET_MIN_DISTANCE,
@@ -313,7 +708,6 @@
     window.world.sinkDuration = 0;
     window.world.sinkStartDist = TARGET_MIN_DISTANCE;
     window.world.sinkEndDist = TARGET_MIN_DISTANCE;
-    window.world.pendingCatchSims = [];
     if (window.waveEffect) {
       window.waveEffect.playing = false;
       window.waveEffect.frameIndex = 0;
@@ -338,12 +732,12 @@
     window.camera.y = 0;
     window.world.actives = [];
     window.world.catches = [];
-    window.world.pendingCatchSims = [];
     window.resultsIndex = 0;
     window.world.time = 0;
     window.world.targetZoom = 1;
     window.world.viewZoom = 1;
     window.world.bobberVisible = false;
+    resetReelBattle();
     if (window.waveEffect) {
       window.waveEffect.playing = false;
       window.waveEffect.frameIndex = 0;
@@ -372,7 +766,6 @@
       }
     }
     resetTargetCircle();
-    clearCatchSimulations();
     updateDistanceReadout();
     if (window.minimap) window.minimap.style.display = 'flex';
     if (window.distanceEl) window.distanceEl.style.display = 'block';
@@ -385,6 +778,7 @@
     window.camera.y = 0;
     setCastPrompt(false);
     awardRemainingCatchPoints();
+    resetReelBattle();
     window.world.targetCircle = null;
     window.world.actives = [];
     window.world.catches = [];
@@ -399,8 +793,6 @@
     window.world.sinkDuration = 0;
     window.world.sinkStartDist = TARGET_MIN_DISTANCE;
     window.world.sinkEndDist = TARGET_MIN_DISTANCE;
-    window.world.pendingCatchSims = [];
-    clearCatchSimulations();
     window.resultsIndex = 0;
     if (window.results) window.results.style.display = 'none';
     if (window.minimap) window.minimap.style.display = 'none';
@@ -457,10 +849,6 @@
     target.reachedTop = false;
     setCastPrompt(false);
     startCharacterCastAnimation();
-  }
-
-  function clearCatchSimulations() {
-    window.world.pendingCatchSims = [];
   }
 
   function triggerBobberImpact(distance) {
@@ -543,50 +931,9 @@
     window.world.castDistance = target.distance;
     scatterFishesAroundTarget(target.distance);
     triggerBobberImpact(target.distance);
-    clearCatchSimulations();
     window.world.targetCircle = null;
     setCastPrompt(true, 'Pull!');
     updateDistanceReadout();
-  }
-
-  function updateCatchSimulations(dt) {
-    if (!Array.isArray(window.world.pendingCatchSims)) {
-      window.world.pendingCatchSims = [];
-    }
-    const sims = window.world.pendingCatchSims;
-    const actives = Array.isArray(window.world.actives) ? window.world.actives : [];
-
-    for (const active of actives) {
-      if (!active || !active.fish) continue;
-      let sim = sims.find(entry => entry.fish === active.fish);
-      if (!sim) {
-        sim = {
-          fish: active.fish,
-          active,
-          successes: 0,
-          failures: 0,
-          timer: window.rand(0, 0.2),
-          interval: window.rand(0.25, 0.55),
-          lastOutcome: null
-        };
-        sims.push(sim);
-      }
-      sim.active = active;
-      sim.timer += dt;
-      while (sim.timer >= sim.interval) {
-        sim.timer -= sim.interval;
-        const success = rollCatch(active);
-        if (success) {
-          sim.successes += 1;
-        } else {
-          sim.failures += 1;
-        }
-        sim.lastOutcome = success;
-        sim.interval = window.rand(0.25, 0.55);
-      }
-    }
-
-    window.world.pendingCatchSims = sims.filter(sim => actives.includes(sim.active));
   }
 
   function updateSinkPhase(dt) {
@@ -598,7 +945,6 @@
     const nextDist = window.lerp(window.world.sinkStartDist, window.world.sinkEndDist, eased);
     window.world.bobberDist = window.clamp(nextDist, SINK_MIN_DISTANCE, TARGET_MAX_DISTANCE);
     updateDistanceReadout();
-    updateCatchSimulations(dt);
     if (window.world.sinkTimer >= duration) {
       finalizeCatchAttempt();
     }
@@ -626,53 +972,33 @@
     window.world.castStage = 'resolved';
     setCastPrompt(false);
     const actives = Array.isArray(window.world.actives) ? window.world.actives.slice() : [];
-    const sims = Array.isArray(window.world.pendingCatchSims) ? window.world.pendingCatchSims : [];
-    const caughtNow = [];
     let anyActive = false;
-
     for (const active of actives) {
       if (!active || !active.fish) continue;
       anyActive = true;
-      const fish = active.fish;
-      const sim = sims.find(entry => entry.fish === fish) || null;
-      let success = false;
-      if (sim) {
-        const totalChecks = sim.successes + sim.failures;
-        if (totalChecks === 0) {
-          success = rollCatch(active);
-        } else if (sim.successes === sim.failures) {
-          success = sim.lastOutcome ?? rollCatch(active);
-        } else {
-          success = sim.successes > sim.failures;
-        }
-      } else {
-        success = rollCatch(active);
-      }
-
-      if (success) {
-        fish.finished = true;
-        fish.engaged = false;
-        if (fish.active) fish.active = null;
-        caughtNow.push(fish);
-        window.world.catches.push(fish);
-      }
       releaseActiveCircle(active, false);
     }
-
     window.world.actives = [];
-    clearCatchSimulations();
     window.world.bobberVisible = false;
 
-    if (caughtNow.length) {
-      showResults();
+    const detectionRange = window.DETECTION_RANGE_M ?? 5;
+    const candidates = gatherFishCandidates(detectionRange);
+    if (!candidates.length) {
+      window.showMissEffect();
+      if (!anyActive) {
+        window.toast('Miss – no fish bit the bobber.');
+      }
+      preparePlayRound(true);
       return;
     }
 
-    window.showMissEffect();
-    if (!anyActive) {
-      window.toast('Miss – no fish bit the bobber.');
+    for (const fish of candidates) {
+      if (!fish) continue;
+      fish.engaged = false;
+      if (fish.active) fish.active = null;
     }
-    preparePlayRound(true);
+    window.world.catches = [];
+    startReelBattleSequence(candidates);
   }
 
   function handlePointerUp() {
@@ -710,8 +1036,6 @@
 
     const fish = window.world.catches[window.resultsIndex];
     const points = computePoints(fish, window.world.castDistance);
-    window.settings.points += points;
-    window.setHUD();
 
     window.rTitle.textContent = `Catch ${window.resultsIndex + 1}/${count}`;
     const escapeHtml = value => String(value ?? '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
@@ -743,18 +1067,7 @@
   }
 
   function awardRemainingCatchPoints() {
-    if (!Array.isArray(window.world.catches) || !window.world.catches.length) return;
-    let bonus = 0;
-    for (let i = window.resultsIndex + 1; i < window.world.catches.length; i++) {
-      const fish = window.world.catches[i];
-      if (!fish) continue;
-      const points = computePoints(fish, window.world.castDistance);
-      window.settings.points += points;
-      bonus += points;
-    }
-    if (bonus > 0) {
-      window.setHUD();
-    }
+    return;
   }
 
   function closeResultsToContinue() {
@@ -1084,6 +1397,7 @@
     updateCharacterAnimation(dt);
     updateFishSimulation(dt);
     updateBobberWave(dt);
+    updateReelBattle(dt);
 
     const metrics = getEnvironmentMetrics(window.canvas.width, window.canvas.height);
     if (window.state === window.GameState.Targeting) {
@@ -1159,6 +1473,20 @@
     window.rSkip.addEventListener('click', () => {
       closeResultsToContinue();
     });
+
+    if (reelBattle.nextBtn) {
+      reelBattle.nextBtn.addEventListener('click', () => {
+        if (!reelBattle.state || !reelBattle.state.resolved) return;
+        reelBattle.state = null;
+        beginNextReelBattle();
+      });
+    }
+
+    if (reelBattle.summaryClose) {
+      reelBattle.summaryClose.addEventListener('click', () => {
+        closeCatchSummary();
+      });
+    }
 
     const comingSoon = label => () => window.toast(`${label} – Coming Soon`);
     if (window.shopBtn) window.shopBtn.addEventListener('click', comingSoon('Shop'));

--- a/js/state.js
+++ b/js/state.js
@@ -154,7 +154,10 @@ window.world = {
   sinkDuration: 0,
   sinkStartDist: 0,
   sinkEndDist: 0,
-  pendingCatchSims: []
+  battleQueue: [],
+  battleResults: [],
+  currentBattleIndex: -1,
+  pendingPointTotal: 0
 };
 
 window.camera = { y: 0 };

--- a/js/utils.js
+++ b/js/utils.js
@@ -63,6 +63,22 @@ window.setHUD = function setHUD() {
   if (window.pointsEl) window.pointsEl.textContent = window.settings.points;
 };
 
+window.addPointsWithSparkle = function addPointsWithSparkle(amount) {
+  if (!Number.isFinite(amount) || amount === 0) {
+    window.setHUD();
+    return;
+  }
+  window.settings.points += amount;
+  window.setHUD();
+  const target = window.pointsEl?.closest?.('.pill') || window.pointsEl;
+  if (!target) return;
+  target.classList.remove('sparkle');
+  void target.offsetWidth;
+  target.classList.add('sparkle');
+  clearTimeout(target._sparkleTimer);
+  target._sparkleTimer = setTimeout(() => target.classList.remove('sparkle'), 900);
+};
+
 window.setGameplayLayout = function setGameplayLayout(active) {
   const container = document.getElementById('game');
   if (container) container.classList.toggle('gameplay', !!active);


### PR DESCRIPTION
## Summary
- add a dedicated Reel battle modal and summary overlay with gauge, fish animation, and totals
- replace timing-circle resolution with a queued reel battle mini-game that precomputes outcomes and awards points after the summary
- add a sparkle points update helper and persist new reel battle state fields

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d634410758832aa8839a923c9b4fe4