### PR TITLE
Add auto play controls and reel battle countdown

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,6 +69,38 @@
       font-size: 14px;
       font-weight: 600;
       backdrop-filter: blur(10px);
+      position: relative;
+      overflow: hidden;
+    }
+
+    .pill.sparkle {
+      animation: sparkleFlash 0.9s ease-out;
+      box-shadow: 0 0 24px rgba(111, 255, 233, 0.45);
+    }
+
+    .pill.sparkle::after {
+      content: '';
+      position: absolute;
+      top: -40%;
+      left: -30%;
+      width: 40%;
+      height: 180%;
+      background: linear-gradient(120deg, rgba(111, 255, 233, 0), rgba(255, 255, 255, 0.75), rgba(111, 255, 233, 0));
+      transform: rotate(25deg);
+      animation: sparkleSweep 0.9s ease-out;
+      pointer-events: none;
+    }
+
+    @keyframes sparkleFlash {
+      0% { transform: scale(1); box-shadow: 0 0 0 rgba(111, 255, 233, 0.1); }
+      40% { transform: scale(1.05); box-shadow: 0 0 28px rgba(111, 255, 233, 0.55); }
+      100% { transform: scale(1); box-shadow: 0 0 12px rgba(111, 255, 233, 0.2); }
+    }
+
+    @keyframes sparkleSweep {
+      0% { transform: translateX(0) rotate(25deg); opacity: 0; }
+      40% { opacity: 1; }
+      100% { transform: translateX(220%) rotate(25deg); opacity: 0; }
     }
 
     #titleBar {
@@ -227,6 +259,36 @@
       background: rgba(15, 23, 42, 0.95);
     }
 
+    #autoBtn {
+      position: absolute;
+      bottom: 90px;
+      right: 24px;
+      padding: 10px 20px;
+      border-radius: 16px;
+      background: rgba(2, 8, 23, 0.85);
+      color: var(--text);
+      font-weight: 600;
+      letter-spacing: 0.04em;
+      border: 1px solid rgba(255, 255, 255, 0.12);
+      cursor: pointer;
+      z-index: 40;
+      opacity: 0;
+      pointer-events: none;
+      transform: translateY(16px);
+      transition: opacity 0.35s ease, transform 0.35s ease, background 0.25s ease, border-color 0.25s ease;
+    }
+
+    #autoBtn.active {
+      background: rgba(91, 192, 190, 0.18);
+      border-color: rgba(111, 255, 233, 0.45);
+      color: var(--secondary);
+    }
+
+    #autoBtn:hover {
+      border-color: rgba(111, 255, 233, 0.45);
+      background: rgba(15, 23, 42, 0.95);
+    }
+
     .cast-prompt {
       position: absolute;
       top: 75%;
@@ -280,6 +342,12 @@
     }
 
     #game.gameplay #exitBtn {
+      opacity: 1;
+      pointer-events: auto;
+      transform: translateY(0);
+    }
+
+    #game.gameplay #autoBtn {
       opacity: 1;
       pointer-events: auto;
       transform: translateY(0);
@@ -440,6 +508,195 @@
       backdrop-filter: blur(10px);
     }
 
+    .battle-modal .battle-card,
+    .battle-summary .battle-summary-card {
+      background: linear-gradient(160deg, rgba(28, 37, 65, 0.95), rgba(15, 23, 42, 0.92));
+      border: 1px solid rgba(111, 255, 233, 0.18);
+      box-shadow: 0 18px 40px rgba(2, 8, 23, 0.65);
+      padding: 28px 26px;
+      border-radius: 22px;
+      width: min(420px, 92vw);
+      color: var(--text);
+      position: relative;
+      overflow: hidden;
+    }
+
+    .battle-card h3 {
+      font-size: 1.6rem;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      margin-bottom: 22px;
+    }
+
+    .battle-gauge {
+      margin: 0 auto 22px;
+      width: 100%;
+      max-width: 320px;
+    }
+
+    .gauge-track {
+      position: relative;
+      width: 100%;
+      height: 26px;
+      border-radius: 18px;
+      overflow: hidden;
+      background: rgba(148, 163, 184, 0.25);
+      border: 1px solid rgba(111, 255, 233, 0.25);
+    }
+
+    .gauge-white {
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      background: linear-gradient(90deg, rgba(255,255,255,0.85), rgba(241,245,249,0.6));
+      border-radius: 18px;
+    }
+
+    .gauge-red {
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      left: 50%;
+      transform: translateX(-50%);
+      width: 22%;
+      background: linear-gradient(90deg, rgba(248, 113, 113, 0.92), rgba(239, 68, 68, 0.92));
+      box-shadow: inset 0 0 15px rgba(127, 29, 29, 0.6);
+    }
+
+    .gauge-fish {
+      position: absolute;
+      top: 50%;
+      width: 16px;
+      height: 16px;
+      background: #111827;
+      border-radius: 8px;
+      transform: translate(-50%, -50%);
+      box-shadow: 0 0 12px rgba(0, 0, 0, 0.45);
+    }
+
+    .battle-fish {
+      position: relative;
+      height: 140px;
+      margin-bottom: 16px;
+    }
+
+    .battle-fish-image {
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      transition: transform 0.5s ease, filter 0.5s ease;
+      max-width: 220px;
+    }
+
+    .battle-fish-image img,
+    .battle-fish-image .placeholder {
+      display: block;
+      width: 100%;
+      height: auto;
+      filter: drop-shadow(0 16px 25px rgba(0, 0, 0, 0.45));
+    }
+
+    .battle-fish-image img {
+      transition: transform 0.25s ease;
+    }
+
+    .battle-fish-image.flip img {
+      transform: scaleX(-1);
+    }
+
+    .battle-fish-image .placeholder {
+      width: 180px;
+      height: 64px;
+      border-radius: 18px;
+      background: rgba(30, 64, 175, 0.25);
+      border: 1px dashed rgba(148, 163, 184, 0.4);
+    }
+
+    .battle-fish-image.celebrate {
+      transform: translate(-50%, -50%) scale(1.2);
+      filter: drop-shadow(0 0 24px rgba(111, 255, 233, 0.55));
+    }
+
+    .battle-status {
+      font-size: 1.2rem;
+      font-weight: 700;
+      letter-spacing: 0.04em;
+      min-height: 1.4em;
+      margin-bottom: 12px;
+      text-align: center;
+    }
+
+    .battle-status.success { color: var(--success); }
+    .battle-status.fail { color: var(--error); }
+
+    .battle-info {
+      text-align: center;
+      font-size: 0.95rem;
+      line-height: 1.5;
+      color: var(--text-dim);
+      min-height: 60px;
+    }
+
+    .battle-info strong { color: var(--secondary); }
+
+    .battle-actions {
+      display: flex;
+      justify-content: center;
+      margin-top: 22px;
+      gap: 12px;
+    }
+
+    .battle-actions .btn { min-width: 140px; }
+
+    .battle-actions .btn.disabled {
+      pointer-events: none;
+      opacity: 0.5;
+    }
+
+    .battle-next-countdown {
+      align-self: center;
+      font-weight: 600;
+      color: var(--text-dim);
+      min-width: 58px;
+      text-align: left;
+      opacity: 0;
+      transition: opacity 0.2s ease;
+    }
+
+    .battle-next-countdown.show {
+      opacity: 1;
+    }
+
+    .battle-summary-card h3 {
+      font-size: 1.5rem;
+      margin-bottom: 18px;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+    }
+
+    .battle-summary-list {
+      max-height: 220px;
+      overflow-y: auto;
+      margin-bottom: 18px;
+      padding-right: 6px;
+    }
+
+    .battle-summary-list p {
+      font-size: 0.95rem;
+      margin-bottom: 8px;
+      display: flex;
+      justify-content: space-between;
+      gap: 12px;
+    }
+
+    .battle-summary-total {
+      font-weight: 700;
+      font-size: 1.1rem;
+      text-align: center;
+      margin-bottom: 18px;
+    }
+
     .card {
       background: var(--bg-light);
       padding: 30px;
@@ -544,6 +801,7 @@
     </div>
 
     <button id="exitBtn" type="button">Exit</button>
+    <button id="autoBtn" type="button" aria-pressed="false">Auto</button>
 
     <div class="version-tag" id="versionTag" aria-hidden="true">v1.0.3</div>
     <div class="toast" id="toast"></div>
@@ -565,6 +823,39 @@
         <div class="actions">
           <div class="btn" id="rSkip">Skip</div>
           <div class="btn primary" id="rNext">Next</div>
+        </div>
+      </div>
+    </div>
+
+    <div class="modal battle-modal" id="reelBattleModal" aria-hidden="true">
+      <div class="battle-card">
+        <h3>Reel battle</h3>
+        <div class="battle-gauge">
+          <div class="gauge-track">
+            <div class="gauge-white" id="battleGaugeWhite"></div>
+            <div class="gauge-red"></div>
+            <div class="gauge-fish" id="battleGaugeFish"></div>
+          </div>
+        </div>
+        <div class="battle-fish">
+          <div class="battle-fish-image" id="battleFishImage"></div>
+        </div>
+        <div class="battle-status" id="battleStatus"></div>
+        <div class="battle-info" id="battleInfo"></div>
+        <div class="battle-actions">
+          <button class="btn primary" id="battleNext" type="button">Next</button>
+          <span class="battle-next-countdown" id="battleNextCountdown"></span>
+        </div>
+      </div>
+    </div>
+
+    <div class="modal battle-summary" id="catchSummary" aria-hidden="true">
+      <div class="battle-summary-card">
+        <h3>Catch Summary</h3>
+        <div class="battle-summary-list" id="summaryList"></div>
+        <div class="battle-summary-total">Total Point: <span id="summaryTotal">0</span></div>
+        <div class="battle-actions">
+          <button class="btn primary" id="summaryClose" type="button">Close</button>
         </div>
       </div>
     </div>

--- a/js/state.js
+++ b/js/state.js
@@ -92,6 +92,7 @@ window.mainMenu = null;
 window.titleBar = null;
 window.navBar = null;
 window.exitBtn = null;
+window.autoBtn = null;
 window.shopBtn = null;
 window.rankBtn = null;
 window.premiumBtn = null;
@@ -154,7 +155,14 @@ window.world = {
   sinkDuration: 0,
   sinkStartDist: 0,
   sinkEndDist: 0,
-  pendingCatchSims: []
+  battleQueue: [],
+  battleResults: [],
+  currentBattleIndex: -1,
+  pendingPointTotal: 0,
+  autoMode: false,
+  autoHoldActive: false,
+  autoCastTimer: 0,
+  autoReleaseDelay: 0
 };
 
 window.camera = { y: 0 };

--- a/js/utils.js
+++ b/js/utils.js
@@ -63,6 +63,22 @@ window.setHUD = function setHUD() {
   if (window.pointsEl) window.pointsEl.textContent = window.settings.points;
 };
 
+window.addPointsWithSparkle = function addPointsWithSparkle(amount) {
+  if (!Number.isFinite(amount) || amount === 0) {
+    window.setHUD();
+    return;
+  }
+  window.settings.points += amount;
+  window.setHUD();
+  const target = window.pointsEl?.closest?.('.pill') || window.pointsEl;
+  if (!target) return;
+  target.classList.remove('sparkle');
+  void target.offsetWidth;
+  target.classList.add('sparkle');
+  clearTimeout(target._sparkleTimer);
+  target._sparkleTimer = setTimeout(() => target.classList.remove('sparkle'), 900);
+};
+
 window.setGameplayLayout = function setGameplayLayout(active) {
   const container = document.getElementById('game');
   if (container) container.classList.toggle('gameplay', !!active);
@@ -93,6 +109,11 @@ window.setGameplayLayout = function setGameplayLayout(active) {
   if (window.exitBtn) {
     window.exitBtn.setAttribute('aria-hidden', active ? 'false' : 'true');
     window.exitBtn.tabIndex = active ? 0 : -1;
+  }
+
+  if (window.autoBtn) {
+    window.autoBtn.setAttribute('aria-hidden', active ? 'false' : 'true');
+    window.autoBtn.tabIndex = active ? 0 : -1;
   }
 };
 


### PR DESCRIPTION
## Summary
- add an Auto button to gameplay with supporting state and layout tweaks
- implement automated casting logic, fish direction flipping, and reel battle countdown handling
- automatically advance between reel battle candidates after a 2 second timer while preserving manual control

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d634410758832aa8839a923c9b4fe4