### PR TITLE
Add shop and auto play countdown flow

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,6 +69,42 @@
       font-size: 14px;
       font-weight: 600;
       backdrop-filter: blur(10px);
+      position: relative;
+      overflow: hidden;
+    }
+
+    #energy.overcap {
+      color: #22c55e;
+    }
+
+    .pill.sparkle {
+      animation: sparkleFlash 0.9s ease-out;
+      box-shadow: 0 0 24px rgba(111, 255, 233, 0.45);
+    }
+
+    .pill.sparkle::after {
+      content: '';
+      position: absolute;
+      top: -40%;
+      left: -30%;
+      width: 40%;
+      height: 180%;
+      background: linear-gradient(120deg, rgba(111, 255, 233, 0), rgba(255, 255, 255, 0.75), rgba(111, 255, 233, 0));
+      transform: rotate(25deg);
+      animation: sparkleSweep 0.9s ease-out;
+      pointer-events: none;
+    }
+
+    @keyframes sparkleFlash {
+      0% { transform: scale(1); box-shadow: 0 0 0 rgba(111, 255, 233, 0.1); }
+      40% { transform: scale(1.05); box-shadow: 0 0 28px rgba(111, 255, 233, 0.55); }
+      100% { transform: scale(1); box-shadow: 0 0 12px rgba(111, 255, 233, 0.2); }
+    }
+
+    @keyframes sparkleSweep {
+      0% { transform: translateX(0) rotate(25deg); opacity: 0; }
+      40% { opacity: 1; }
+      100% { transform: translateX(220%) rotate(25deg); opacity: 0; }
     }
 
     #titleBar {
@@ -227,6 +263,42 @@
       background: rgba(15, 23, 42, 0.95);
     }
 
+    #autoBtn {
+      position: absolute;
+      bottom: 90px;
+      right: 24px;
+      padding: 10px 20px;
+      border-radius: 16px;
+      background: rgba(2, 8, 23, 0.85);
+      color: var(--text);
+      font-weight: 600;
+      letter-spacing: 0.04em;
+      border: 1px solid rgba(255, 255, 255, 0.12);
+      cursor: pointer;
+      z-index: 40;
+      opacity: 0;
+      pointer-events: none;
+      transform: translateY(16px);
+      transition: opacity 0.35s ease, transform 0.35s ease, background 0.25s ease, border-color 0.25s ease;
+    }
+
+    #autoBtn.active {
+      background: rgba(91, 192, 190, 0.18);
+      border-color: rgba(111, 255, 233, 0.45);
+      color: var(--secondary);
+    }
+
+    #autoBtn.pending {
+      background: rgba(91, 192, 190, 0.12);
+      border-color: rgba(111, 255, 233, 0.35);
+      color: var(--secondary);
+    }
+
+    #autoBtn:hover {
+      border-color: rgba(111, 255, 233, 0.45);
+      background: rgba(15, 23, 42, 0.95);
+    }
+
     .cast-prompt {
       position: absolute;
       top: 75%;
@@ -280,6 +352,12 @@
     }
 
     #game.gameplay #exitBtn {
+      opacity: 1;
+      pointer-events: auto;
+      transform: translateY(0);
+    }
+
+    #game.gameplay #autoBtn {
       opacity: 1;
       pointer-events: auto;
       transform: translateY(0);
@@ -440,6 +518,436 @@
       backdrop-filter: blur(10px);
     }
 
+    .shop-modal .shop-card {
+      background: linear-gradient(160deg, rgba(28, 37, 65, 0.95), rgba(15, 23, 42, 0.92));
+      border: 1px solid rgba(111, 255, 233, 0.18);
+      box-shadow: 0 18px 40px rgba(2, 8, 23, 0.65);
+      padding: 28px 30px 36px;
+      border-radius: 22px;
+      width: min(420px, 92vw);
+      color: var(--text);
+      position: relative;
+      display: flex;
+      flex-direction: column;
+      gap: 22px;
+    }
+
+    .shop-card h3 {
+      font-size: 1.6rem;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      text-align: center;
+    }
+
+    .shop-close {
+      position: absolute;
+      top: 16px;
+      right: 16px;
+      width: 34px;
+      height: 34px;
+      border-radius: 50%;
+      border: 1px solid rgba(148, 163, 184, 0.35);
+      background: rgba(2, 8, 23, 0.6);
+      color: var(--text);
+      font-size: 1.2rem;
+      font-weight: 600;
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      transition: all 0.2s ease;
+    }
+
+    .shop-close:hover {
+      transform: scale(1.05);
+      border-color: rgba(111, 255, 233, 0.55);
+    }
+
+    .shop-balance {
+      font-size: 0.95rem;
+      color: var(--text-dim);
+      text-align: center;
+    }
+
+    .shop-products {
+      display: flex;
+      flex-direction: column;
+      gap: 16px;
+      max-height: min(320px, 50vh);
+      overflow-y: auto;
+      padding-right: 4px;
+    }
+
+    .shop-products::-webkit-scrollbar {
+      width: 6px;
+    }
+
+    .shop-products::-webkit-scrollbar-thumb {
+      background: rgba(111, 255, 233, 0.25);
+      border-radius: 3px;
+    }
+
+    .shop-item {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 14px 18px;
+      background: rgba(9, 14, 31, 0.65);
+      border: 1px solid rgba(111, 255, 233, 0.18);
+      border-radius: 16px;
+      gap: 20px;
+    }
+
+    .shop-item .details {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+    }
+
+    .shop-item h4 {
+      font-size: 1.05rem;
+      font-weight: 700;
+      letter-spacing: 0.04em;
+    }
+
+    .shop-item p {
+      font-size: 0.9rem;
+      color: var(--text-dim);
+    }
+
+    .shop-item button {
+      padding: 10px 20px;
+      border-radius: 999px;
+      border: none;
+      background: var(--primary);
+      color: #fff;
+      font-weight: 600;
+      cursor: pointer;
+      transition: transform 0.2s ease, opacity 0.2s ease;
+      min-width: 96px;
+    }
+
+    .shop-item button:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+
+    .shop-item button:not(:disabled):hover {
+      transform: translateY(-1px);
+    }
+
+    .auto-countdown {
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%) scale(0.92);
+      background: rgba(2, 8, 23, 0.82);
+      border: 1px solid rgba(111, 255, 233, 0.25);
+      border-radius: 18px;
+      padding: 26px 36px;
+      text-align: center;
+      color: var(--text);
+      box-shadow: 0 18px 48px rgba(2, 8, 23, 0.6);
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 0.25s ease, transform 0.25s ease;
+      z-index: 120;
+    }
+
+    .auto-countdown.show {
+      opacity: 1;
+      transform: translate(-50%, -50%) scale(1);
+    }
+
+    .auto-countdown-title {
+      font-size: 1.2rem;
+      font-weight: 700;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+    }
+
+    .auto-countdown-timer {
+      margin-top: 8px;
+      font-size: 2.6rem;
+      font-weight: 800;
+      color: var(--secondary);
+      letter-spacing: 0.08em;
+    }
+
+    .auto-countdown-timer span {
+      font-size: 1rem;
+      margin-left: 4px;
+      color: var(--text-dim);
+    }
+
+    .battle-modal .battle-card,
+    .battle-summary .battle-summary-card {
+      background: linear-gradient(160deg, rgba(28, 37, 65, 0.95), rgba(15, 23, 42, 0.92));
+      border: 1px solid rgba(111, 255, 233, 0.18);
+      box-shadow: 0 18px 40px rgba(2, 8, 23, 0.65);
+      padding: 28px 26px;
+      border-radius: 22px;
+      width: min(420px, 92vw);
+      color: var(--text);
+      position: relative;
+      overflow: hidden;
+    }
+
+    .battle-card h3 {
+      font-size: 1.6rem;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      margin-bottom: 22px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 12px;
+      text-align: center;
+    }
+
+    .battle-card h3 .battle-title {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: 6px;
+    }
+
+    .battle-card h3 .battle-counter {
+      font-size: 1rem;
+      letter-spacing: 0.05em;
+      text-transform: none;
+      color: var(--secondary);
+    }
+
+    .battle-gauge {
+      margin: 0 auto 22px;
+      width: 100%;
+      max-width: 320px;
+    }
+
+    .gauge-track {
+      position: relative;
+      width: 100%;
+      height: 26px;
+      border-radius: 18px;
+      overflow: hidden;
+      background: rgba(148, 163, 184, 0.25);
+      border: 1px solid rgba(111, 255, 233, 0.25);
+    }
+
+    .gauge-white {
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      background: linear-gradient(90deg, rgba(255,255,255,0.85), rgba(241,245,249,0.6));
+      border-radius: 18px;
+    }
+
+    .gauge-red {
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      left: 50%;
+      transform: translateX(-50%);
+      width: 22%;
+      background: linear-gradient(90deg, rgba(248, 113, 113, 0.92), rgba(239, 68, 68, 0.92));
+      box-shadow: inset 0 0 15px rgba(127, 29, 29, 0.6);
+    }
+
+    .gauge-fish {
+      position: absolute;
+      top: 50%;
+      width: 16px;
+      height: 16px;
+      background: #111827;
+      border-radius: 8px;
+      transform: translate(-50%, -50%);
+      box-shadow: 0 0 12px rgba(0, 0, 0, 0.45);
+    }
+
+    .battle-fish {
+      position: relative;
+      height: 140px;
+      margin-bottom: 16px;
+    }
+
+    .battle-fish-image {
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      transition: transform 0.5s ease, filter 0.5s ease;
+      max-width: 220px;
+    }
+
+    .battle-fish-image img,
+    .battle-fish-image .placeholder {
+      display: block;
+      width: 100%;
+      height: auto;
+      filter: drop-shadow(0 16px 25px rgba(0, 0, 0, 0.45));
+    }
+
+    .battle-fish-image img {
+      transition: transform 0.25s ease;
+    }
+
+    .battle-fish-image.flip img {
+      transform: scaleX(-1);
+    }
+
+    .battle-fish-image .placeholder {
+      width: 180px;
+      height: 64px;
+      border-radius: 18px;
+      background: rgba(30, 64, 175, 0.25);
+      border: 1px dashed rgba(148, 163, 184, 0.4);
+    }
+
+    .battle-fish-image.celebrate {
+      transform: translate(-50%, -50%) scale(1.2);
+      filter: drop-shadow(0 0 24px rgba(111, 255, 233, 0.55));
+    }
+
+    .battle-fish-image .treasure-chest {
+      position: absolute;
+      width: 140px;
+      height: 96px;
+      border-radius: 16px 16px 20px 20px;
+      background: linear-gradient(180deg, #facc15, #d97706 65%, #92400e);
+      box-shadow: 0 16px 32px rgba(234, 179, 8, 0.4);
+      overflow: hidden;
+      transform: translate(-50%, -50%);
+      left: 50%;
+      top: 50%;
+    }
+
+    .battle-fish-image .treasure-chest::before {
+      content: '';
+      position: absolute;
+      left: 0;
+      right: 0;
+      top: 0;
+      height: 42%;
+      background: linear-gradient(180deg, #fde68a, #f59e0b);
+      border-bottom: 4px solid rgba(146, 64, 14, 0.4);
+    }
+
+    .battle-fish-image .treasure-chest::after {
+      content: '';
+      position: absolute;
+      left: 50%;
+      top: 30%;
+      width: 18px;
+      height: 38px;
+      background: linear-gradient(180deg, #7c2d12, #fbbf24);
+      border-radius: 6px;
+      transform: translateX(-50%);
+      box-shadow: inset 0 0 6px rgba(0, 0, 0, 0.35);
+    }
+
+    .battle-fish-image .treasure-chest .shine {
+      position: absolute;
+      left: -40%;
+      top: -20%;
+      width: 60%;
+      height: 160%;
+      background: linear-gradient(120deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.65), rgba(255, 255, 255, 0));
+      transform: rotate(25deg);
+      animation: chestShimmer 2.6s linear infinite;
+    }
+
+    @keyframes chestShimmer {
+      0% { transform: translateX(0) rotate(25deg); opacity: 0; }
+      40% { opacity: 1; }
+      100% { transform: translateX(220%) rotate(25deg); opacity: 0; }
+    }
+
+    .battle-status {
+      font-size: 1.2rem;
+      font-weight: 700;
+      letter-spacing: 0.04em;
+      min-height: 1.4em;
+      margin-bottom: 12px;
+      text-align: center;
+    }
+
+    .battle-status.success { color: var(--success); }
+    .battle-status.fail { color: var(--error); }
+
+    .battle-info {
+      text-align: center;
+      font-size: 0.95rem;
+      line-height: 1.5;
+      color: var(--text-dim);
+      min-height: 60px;
+    }
+
+    .battle-info strong { color: var(--secondary); }
+
+    .battle-actions {
+      display: flex;
+      justify-content: center;
+      margin-top: 22px;
+      gap: 12px;
+    }
+
+    .battle-actions .btn { min-width: 140px; }
+
+    .battle-actions .btn.disabled {
+      pointer-events: none;
+      opacity: 0.5;
+    }
+
+    .battle-next-countdown {
+      align-self: center;
+      font-weight: 600;
+      color: var(--text-dim);
+      min-width: 96px;
+      text-align: left;
+      opacity: 0;
+      transition: opacity 0.2s ease;
+    }
+
+    .battle-next-countdown.show {
+      opacity: 1;
+    }
+
+    .battle-summary-card h3 {
+      font-size: 1.5rem;
+      margin-bottom: 18px;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+    }
+
+    .battle-summary-list {
+      max-height: 220px;
+      overflow-y: auto;
+      margin-bottom: 18px;
+      padding-right: 6px;
+    }
+
+    .battle-summary-list p {
+      font-size: 0.95rem;
+      margin-bottom: 8px;
+      display: flex;
+      justify-content: space-between;
+      gap: 12px;
+    }
+
+    .battle-summary-list .summary-energy {
+      justify-content: center;
+      color: var(--secondary);
+      font-weight: 600;
+    }
+
+    .battle-summary-total {
+      font-weight: 700;
+      font-size: 1.1rem;
+      text-align: center;
+      margin-bottom: 18px;
+    }
+
     .card {
       background: var(--bg-light);
       padding: 30px;
@@ -525,10 +1033,10 @@
 
     <div class="hud">
       <div class="left">
-        <div class="pill">⚡ Energy: <span id="energy">10</span></div>
+        <div class="pill">⚡ Energy: <span id="energy">10/10</span></div>
       </div>
       <div class="right">
-        <div class="pill">🎣 Points: <span id="points">0</span></div>
+        <div class="pill">🎣 Points: <span id="points">3,000</span></div>
       </div>
     </div>
 
@@ -543,12 +1051,30 @@
       <button class="nav-btn" id="premiumBtn" type="button">Premium Mode</button>
     </div>
 
+    <div class="modal shop-modal" id="shopModal" aria-hidden="true">
+      <div class="shop-card">
+        <button class="shop-close" id="shopClose" type="button" aria-label="Close shop">×</button>
+        <h3>Shop</h3>
+        <p class="shop-balance">현재 포인트: <span id="shopPoints">3,000</span></p>
+        <div class="shop-products" id="shopProducts"></div>
+      </div>
+    </div>
+
     <button id="exitBtn" type="button">Exit</button>
+    <button id="autoBtn" type="button" aria-pressed="false">Auto</button>
 
     <div class="version-tag" id="versionTag" aria-hidden="true">v1.0.3</div>
     <div class="toast" id="toast"></div>
     <div class="miss-effect" id="missEffect">MISS!</div>
     <div class="distance" id="distance"></div>
+
+    <div class="auto-countdown" id="autoCountdown" aria-hidden="true">
+      <div class="auto-countdown-title">Auto Play Start!</div>
+      <div class="auto-countdown-timer">
+        <span id="autoCountdownTimer">2.0</span>
+        <span>s</span>
+      </div>
+    </div>
 
     <div class="minimap" id="minimap" aria-hidden="true">
       <div class="mmbar" id="mmbar">
@@ -565,6 +1091,40 @@
         <div class="actions">
           <div class="btn" id="rSkip">Skip</div>
           <div class="btn primary" id="rNext">Next</div>
+        </div>
+      </div>
+    </div>
+
+    <div class="modal battle-modal" id="reelBattleModal" aria-hidden="true">
+      <div class="battle-card">
+        <h3><span class="battle-title" id="battleTitle">Reel battle</span><span class="battle-counter" id="battleCounter"></span></h3>
+        <div class="battle-gauge">
+          <div class="gauge-track">
+            <div class="gauge-white" id="battleGaugeWhite"></div>
+            <div class="gauge-red"></div>
+            <div class="gauge-fish" id="battleGaugeFish"></div>
+          </div>
+        </div>
+        <div class="battle-fish">
+          <div class="battle-fish-image" id="battleFishImage"></div>
+        </div>
+        <div class="battle-status" id="battleStatus"></div>
+        <div class="battle-info" id="battleInfo"></div>
+        <div class="battle-actions">
+          <button class="btn primary" id="battleNext" type="button">Next</button>
+          <span class="battle-next-countdown" id="battleNextCountdown"></span>
+        </div>
+      </div>
+    </div>
+
+    <div class="modal battle-summary" id="catchSummary" aria-hidden="true">
+      <div class="battle-summary-card">
+        <h3>Catch Summary</h3>
+        <div class="battle-summary-list" id="summaryList"></div>
+        <div class="battle-summary-total">Total Point: <span id="summaryTotal">0</span></div>
+        <div class="battle-actions">
+          <button class="btn primary" id="summaryClose" type="button">Close</button>
+          <span class="battle-next-countdown summary-countdown" id="summaryCountdown"></span>
         </div>
       </div>
     </div>

--- a/js/main.js
+++ b/js/main.js
@@ -2,6 +2,70 @@
 // Relies on global state defined in state.js and helpers from utils.js.
 
 (function () {
+  const reelBattle = {
+    modal: null,
+    white: null,
+    marker: null,
+    fishImage: null,
+    status: null,
+    info: null,
+    nextBtn: null,
+    counter: null,
+    summaryModal: null,
+    summaryList: null,
+    summaryTotal: null,
+    summaryClose: null,
+    nextCountdownLabel: null,
+    summaryCountdownLabel: null,
+    queue: [],
+    index: -1,
+    results: [],
+    state: null,
+    totalPoints: 0,
+    bonusEnergy: 0,
+    redWidth: 0.22,
+    finalWhite: 0.22,
+    duration: 2.6,
+    autoAdvanceTimer: 0,
+    autoAdvanceActive: false,
+    autoAdvanceMode: 'next',
+    summaryCountdownTimer: 0,
+    summaryCountdownActive: false
+  };
+
+  const SHOP_PRODUCTS = [
+    { id: 'energy-5', name: 'Energy 5', description: '에너지 5 회복', energy: 5, cost: 2000 },
+    { id: 'energy-10', name: 'Energy 10', description: '에너지 10 회복', energy: 10, cost: 4000 },
+    { id: 'energy-20', name: 'Energy 20', description: '에너지 20 회복', energy: 20, cost: 7500 }
+  ];
+
+  const shopUI = {
+    modal: null,
+    list: null,
+    closeBtn: null,
+    buttons: new Map()
+  };
+
+  const FISH_TUG_MESSAGES = [
+    '물고기가 라인을 흔듭니다!',
+    '강하게 저항하고 있어요!',
+    '라인을 가로질러 빠져나가려 해요!'
+  ];
+
+  const PLAYER_TUG_MESSAGES = [
+    '라인을 힘껏 당깁니다!',
+    '낚싯대를 들어 올렸어요!',
+    '챔질에 성공했습니다!'
+  ];
+
+  const TREASURE_MESSAGES = [
+    '반짝이는 것이 보여요!',
+    '상자가 걸린 것 같아요!',
+    '보물의 무게가 전해집니다!'
+  ];
+
+  const ENERGY_WARNING = '에너지가 부족합니다. 플레이를 진행할 수 없습니다.';
+
   function ensureDomReferences() {
     window.canvas = document.getElementById('view');
     window.ctx = window.canvas?.getContext('2d') ?? null;
@@ -10,13 +74,20 @@
     window.titleBar = document.getElementById('titleBar');
     window.navBar = document.getElementById('navBar');
     window.exitBtn = document.getElementById('exitBtn');
+    window.autoBtn = document.getElementById('autoBtn');
     window.shopBtn = document.getElementById('shopBtn');
+    window.shopModal = document.getElementById('shopModal');
+    window.shopCloseBtn = document.getElementById('shopClose');
+    window.shopProducts = document.getElementById('shopProducts');
+    window.shopPointsEl = document.getElementById('shopPoints');
     window.rankBtn = document.getElementById('rankBtn');
     window.premiumBtn = document.getElementById('premiumBtn');
     window.castPrompt = document.getElementById('castPrompt');
     window.toastEl = document.getElementById('toast');
     window.missEffect = document.getElementById('missEffect');
     window.distanceEl = document.getElementById('distance');
+    window.autoCountdownEl = document.getElementById('autoCountdown');
+    window.autoCountdownTimerEl = document.getElementById('autoCountdownTimer');
     window.minimap = document.getElementById('minimap');
     window.mmbar = document.getElementById('mmbar');
     window.mmCells = document.getElementById('mmcells');
@@ -29,6 +100,29 @@
     window.rSkip = document.getElementById('rSkip');
     window.energyEl = document.getElementById('energy');
     window.pointsEl = document.getElementById('points');
+    reelBattle.modal = document.getElementById('reelBattleModal');
+    reelBattle.white = document.getElementById('battleGaugeWhite');
+    reelBattle.marker = document.getElementById('battleGaugeFish');
+    reelBattle.fishImage = document.getElementById('battleFishImage');
+    reelBattle.status = document.getElementById('battleStatus');
+    reelBattle.info = document.getElementById('battleInfo');
+    reelBattle.nextBtn = document.getElementById('battleNext');
+    reelBattle.counter = document.getElementById('battleCounter');
+    reelBattle.summaryModal = document.getElementById('catchSummary');
+    reelBattle.summaryList = document.getElementById('summaryList');
+    reelBattle.summaryTotal = document.getElementById('summaryTotal');
+    reelBattle.summaryClose = document.getElementById('summaryClose');
+    reelBattle.nextCountdownLabel = document.getElementById('battleNextCountdown');
+    reelBattle.summaryCountdownLabel = document.getElementById('summaryCountdown');
+
+    shopUI.modal = window.shopModal;
+    shopUI.list = window.shopProducts;
+    shopUI.closeBtn = window.shopCloseBtn;
+    window.updateShopAvailability = updateShopAvailability;
+    buildShopProducts();
+    updateShopAvailability();
+    updateAutoCountdownUI();
+    updateAutoButtonUI();
 
     if (!window.canvas || !window.ctx || !window.startBtn || !window.mainMenu) {
       throw new Error('Essential DOM elements are missing.');
@@ -297,6 +391,1128 @@
     window.castPrompt.classList.toggle('show', !!visible);
   }
 
+  function escapeHtml(value) {
+    return String(value ?? '')
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
+  function pickMessage(list) {
+    if (!Array.isArray(list) || !list.length) return '';
+    const index = Math.floor(Math.random() * list.length);
+    return list[index];
+  }
+
+  function setModalVisibility(element, visible) {
+    if (!element) return;
+    element.style.display = visible ? 'flex' : 'none';
+    element.setAttribute('aria-hidden', visible ? 'false' : 'true');
+  }
+
+  function updateShopAvailability() {
+    const points = window.settings.points ?? 0;
+    shopUI.buttons.forEach(entry => {
+      if (!entry || !entry.button) return;
+      const price = Math.max(0, Math.round(entry.product.cost ?? 0));
+      entry.button.disabled = points < price;
+    });
+  }
+
+  function buildShopProducts() {
+    if (!shopUI.list) return;
+    if (shopUI.buttons.size) {
+      updateShopAvailability();
+      return;
+    }
+    shopUI.list.innerHTML = '';
+    shopUI.buttons.clear();
+    SHOP_PRODUCTS.forEach(product => {
+      const item = document.createElement('div');
+      item.className = 'shop-item';
+
+      const details = document.createElement('div');
+      details.className = 'details';
+
+      const title = document.createElement('h4');
+      title.textContent = product.name;
+
+      const desc = document.createElement('p');
+      const benefit = product.energy ? `Energy +${product.energy}` : product.description || '';
+      const costText = `${product.cost.toLocaleString()} Point`;
+      desc.textContent = benefit ? `${costText} • ${benefit}` : costText;
+
+      details.appendChild(title);
+      details.appendChild(desc);
+
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.textContent = '구매';
+      button.addEventListener('click', () => purchaseShopItem(product));
+
+      item.appendChild(details);
+      item.appendChild(button);
+
+      shopUI.list.appendChild(item);
+      shopUI.buttons.set(product.id, { button, product });
+    });
+    updateShopAvailability();
+  }
+
+  function openShop() {
+    buildShopProducts();
+    if (shopUI.modal) {
+      setModalVisibility(shopUI.modal, true);
+    }
+  }
+
+  function closeShop() {
+    if (shopUI.modal) {
+      setModalVisibility(shopUI.modal, false);
+    }
+  }
+
+  function purchaseShopItem(product) {
+    if (!product) return;
+    const cost = Math.max(0, Math.round(product.cost ?? 0));
+    if (cost > 0 && (window.settings.points ?? 0) < cost) {
+      window.toast('포인트가 부족합니다.');
+      return;
+    }
+    let spent = false;
+    if (cost > 0) {
+      spent = window.spendPoints(cost);
+      if (!spent) {
+        window.toast('포인트가 부족합니다.');
+        return;
+      }
+    }
+    let granted = false;
+    try {
+      if (product.energy) {
+        const amount = Math.max(0, Math.round(product.energy));
+        if (amount > 0) {
+          window.addEnergy(amount, { toast: `${product.name} 구매! Energy +${amount}` });
+          granted = true;
+        }
+      }
+      if (typeof product.onPurchase === 'function') {
+        const result = product.onPurchase();
+        if (result === false) {
+          if (spent && cost > 0) {
+            window.settings.points += cost;
+            window.setHUD();
+          }
+          updateShopAvailability();
+          window.toast('구매가 취소되었습니다.');
+          return;
+        }
+        granted = true;
+      }
+    } catch (err) {
+      console.error('Shop purchase failed:', err);
+      if (spent && cost > 0) {
+        window.settings.points += cost;
+        window.setHUD();
+      }
+      updateShopAvailability();
+      window.toast('구매 처리 중 오류가 발생했습니다.');
+      return;
+    }
+    if (!granted) {
+      window.toast(`${product.name} 구매 완료!`);
+      window.setHUD();
+    }
+    updateShopAvailability();
+  }
+
+  function updateBattleCounter() {
+    if (!reelBattle.counter) return;
+    const total = Array.isArray(reelBattle.queue) ? reelBattle.queue.length : 0;
+    if (!total || reelBattle.index < 0 || reelBattle.index >= total) {
+      reelBattle.counter.textContent = '';
+      return;
+    }
+    const current = Math.min(reelBattle.index + 1, total);
+    reelBattle.counter.textContent = `${current}/${total}`;
+  }
+
+  function setBattleStatusMessage(state, message, duration = 1.1) {
+    if (!reelBattle.status || !state || state.resolved) return;
+    if (typeof message !== 'string' || !message.trim()) return;
+    reelBattle.status.textContent = message;
+    reelBattle.status.classList.remove('success', 'fail');
+    state.statusTimer = Math.max(duration, 0);
+  }
+
+  function clearNextBattleCountdown() {
+    reelBattle.autoAdvanceActive = false;
+    reelBattle.autoAdvanceTimer = 0;
+    reelBattle.autoAdvanceMode = 'next';
+    if (reelBattle.nextCountdownLabel) {
+      reelBattle.nextCountdownLabel.textContent = '';
+      reelBattle.nextCountdownLabel.classList.remove('show');
+    }
+  }
+
+  function startNextBattleCountdown(mode = 'next') {
+    reelBattle.autoAdvanceTimer = 2;
+    reelBattle.autoAdvanceActive = true;
+    reelBattle.autoAdvanceMode = mode === 'summary' ? 'summary' : 'next';
+    if (reelBattle.nextCountdownLabel) {
+      const prefix = reelBattle.autoAdvanceMode === 'summary' ? 'Summary' : 'Next';
+      reelBattle.nextCountdownLabel.textContent = `${prefix} 2.0s`;
+      reelBattle.nextCountdownLabel.classList.add('show');
+    }
+  }
+
+  function clearSummaryCountdown() {
+    reelBattle.summaryCountdownActive = false;
+    reelBattle.summaryCountdownTimer = 0;
+    if (reelBattle.summaryCountdownLabel) {
+      reelBattle.summaryCountdownLabel.textContent = '';
+      reelBattle.summaryCountdownLabel.classList.remove('show');
+    }
+  }
+
+  function startSummaryCountdown() {
+    reelBattle.summaryCountdownTimer = 2;
+    reelBattle.summaryCountdownActive = true;
+    if (reelBattle.summaryCountdownLabel) {
+      reelBattle.summaryCountdownLabel.textContent = 'Close 2.0s';
+      reelBattle.summaryCountdownLabel.classList.add('show');
+    }
+  }
+
+  function updateAutoCountdownUI() {
+    if (!window.autoCountdownEl) return;
+    const active = !!window.world.autoCountdownActive;
+    window.autoCountdownEl.classList.toggle('show', active);
+    window.autoCountdownEl.setAttribute('aria-hidden', active ? 'false' : 'true');
+    if (active && window.autoCountdownTimerEl) {
+      const seconds = Math.max(0, window.world.autoCountdownTimer || 0);
+      window.autoCountdownTimerEl.textContent = seconds.toFixed(1);
+    }
+  }
+
+  function showAutoCountdown(duration = 2, callback) {
+    window.world.autoCountdownActive = true;
+    window.world.autoCountdownTimer = Math.max(0, Number.isFinite(duration) ? duration : 0);
+    window.world.autoCountdownCallback = typeof callback === 'function' ? callback : null;
+    updateAutoCountdownUI();
+    updateAutoButtonUI();
+  }
+
+  function cancelAutoCountdown() {
+    window.world.autoCountdownActive = false;
+    window.world.autoCountdownTimer = 0;
+    window.world.autoCountdownCallback = null;
+    updateAutoCountdownUI();
+    updateAutoButtonUI();
+  }
+
+  function updateAutoButtonUI() {
+    if (!window.autoBtn) return;
+    if (window.world.autoCountdownActive) {
+      const seconds = Math.max(0, window.world.autoCountdownTimer || 0).toFixed(1);
+      window.autoBtn.classList.remove('active');
+      window.autoBtn.classList.add('pending');
+      window.autoBtn.setAttribute('aria-pressed', 'false');
+      window.autoBtn.textContent = `Auto (${seconds}s)`;
+      return;
+    }
+    window.autoBtn.classList.remove('pending');
+    const active = !!window.world.autoMode;
+    window.autoBtn.classList.toggle('active', active);
+    window.autoBtn.setAttribute('aria-pressed', active ? 'true' : 'false');
+    window.autoBtn.textContent = active ? 'Auto On' : 'Auto';
+  }
+
+  function updateAutoCountdown(dt) {
+    if (!window.world.autoCountdownActive) return;
+    const previous = window.world.autoCountdownTimer || 0;
+    const next = Math.max(0, previous - dt);
+    window.world.autoCountdownTimer = next;
+    const prevLabel = Math.max(0, previous).toFixed(1);
+    const nextLabel = Math.max(0, next).toFixed(1);
+    if (nextLabel !== prevLabel || next <= 0) {
+      updateAutoCountdownUI();
+      updateAutoButtonUI();
+    }
+    if (next <= 0) {
+      const callback = window.world.autoCountdownCallback;
+      cancelAutoCountdown();
+      if (typeof callback === 'function') {
+        callback();
+      }
+    }
+  }
+
+  function computeAutoTargetDistance() {
+    const min = TARGET_MIN_DISTANCE;
+    const max = TARGET_MAX_DISTANCE;
+    const fishes = window.world.fishes;
+    if (!Array.isArray(fishes) || !fishes.length) {
+      return window.rand(min + 4, max - 6);
+    }
+
+    const bucketSize = 8;
+    const rarityPriority = window.RARITY_PRIORITY || {};
+    const buckets = new Map();
+
+    for (const fish of fishes) {
+      if (!fish || fish.finished) continue;
+      const distRaw = fish.position?.y ?? fish.distance ?? min;
+      const dist = window.clamp(distRaw, min, max);
+      const bucketIndex = Math.max(0, Math.floor((dist - min) / bucketSize));
+      const rarity = fish.spec?.rarity || 'Common';
+      const priority = rarityPriority[rarity] ?? 0;
+      const weight = 1 + priority * 0.25 + Math.min(1.2, Math.max(0, (fish.schoolSize ?? 1) * 0.12));
+      buckets.set(bucketIndex, (buckets.get(bucketIndex) || 0) + weight);
+    }
+
+    if (!buckets.size) {
+      return window.rand(min + 4, max - 6);
+    }
+
+    const sorted = [...buckets.entries()].sort((a, b) => b[1] - a[1]);
+    const topScore = sorted[0][1];
+    const viable = sorted.filter(([, score]) => score >= topScore * 0.55);
+    const pool = viable.length ? viable : sorted;
+    const total = pool.reduce((sum, [, score]) => sum + score, 0);
+    let pickRoll = Math.random() * (total || 1);
+    let chosen = pool[0];
+    for (const entry of pool) {
+      pickRoll -= entry[1];
+      if (pickRoll <= 0) {
+        chosen = entry;
+        break;
+      }
+    }
+
+    const bucketIndex = chosen?.[0] ?? 0;
+    const bucketStart = min + bucketIndex * bucketSize;
+    const bucketEnd = Math.min(max, bucketStart + bucketSize);
+    const span = Math.max(1.5, bucketEnd - bucketStart);
+    const innerStart = window.clamp(bucketStart + span * 0.2, min, max);
+    const innerEnd = window.clamp(bucketEnd - span * 0.2, min, max);
+    const base = innerEnd > innerStart ? window.rand(innerStart, innerEnd) : (bucketStart + bucketEnd) / 2;
+    const jitter = window.rand(-Math.min(2.2, span * 0.25), Math.min(2.2, span * 0.25));
+    let target = base + jitter;
+    if (Math.random() < 0.12) {
+      target = window.rand(min + 6, max - 6);
+    }
+    return window.clamp(target, min + 1, max - 1);
+  }
+
+  function computeAutoReleaseDelay(distance) {
+    const min = TARGET_MIN_DISTANCE;
+    const max = TARGET_MAX_DISTANCE;
+    const range = Math.max(1, max - min);
+    const ratio = window.clamp((distance - min) / range, 0, 1);
+    const base = 0.85 + ratio * 1.25;
+    return window.clamp(base + window.rand(-0.05, 0.22), 0.75, 2.6);
+  }
+
+  function scheduleAutoCast(delay = 0.45) {
+    if (!window.world.autoMode) return;
+    if (window.state !== window.GameState.Targeting) return;
+    if (window.world.castStage !== 'aiming') return;
+    const target = window.world.targetCircle;
+    if (!target) {
+      window.world.autoArmed = false;
+      return;
+    }
+    window.world.autoArmed = true;
+    window.world.autoCastTimer = Math.max(0, delay);
+    window.world.autoHoldActive = false;
+    const desiredDistance = computeAutoTargetDistance();
+    window.world.autoTargetDistance = desiredDistance;
+    window.world.autoReleaseDelay = computeAutoReleaseDelay(desiredDistance);
+    target.holding = false;
+    target.holdTime = 0;
+    target.velocity = 0;
+    target.reachedTop = false;
+    setCastPrompt(true, 'Auto casting...');
+  }
+
+  function setAutoMode(enabled, schedule = false) {
+    const next = !!enabled;
+    if (window.world.autoMode === next) {
+      if (next && schedule) scheduleAutoCast(window.rand(0.3, 0.6));
+      updateAutoButtonUI();
+      return;
+    }
+    window.world.autoMode = next;
+    window.world.autoHoldActive = false;
+    window.world.autoArmed = false;
+    if (!next) {
+      cancelAutoCountdown();
+      window.world.autoCastTimer = 0;
+      window.world.autoReleaseDelay = 0;
+      window.world.autoTargetDistance = null;
+      if (window.world.targetCircle) {
+        window.world.targetCircle.holding = false;
+      }
+      if (window.state === window.GameState.Targeting && window.world.castStage === 'aiming') {
+        setCastPrompt(true, 'Press the Screen to cast the bobber');
+      }
+    } else if (schedule) {
+      scheduleAutoCast(window.rand(0.3, 0.6));
+    }
+    updateAutoButtonUI();
+  }
+
+  function updateAutoPlay(dt) {
+    if (!window.world.autoMode) return;
+    if (window.state !== window.GameState.Targeting) return;
+    const stage = window.world.castStage;
+    if (stage === 'aiming') {
+      if (!window.world.autoArmed) return;
+      const target = window.world.targetCircle;
+      if (!target) return;
+      if (!window.world.autoHoldActive) {
+        window.world.autoCastTimer -= dt;
+        if (window.world.autoCastTimer <= 0) {
+          if (!target.holding) {
+            handlePointerDown();
+          }
+          if (target.holding) {
+            window.world.autoHoldActive = true;
+            if (!Number.isFinite(window.world.autoTargetDistance)) {
+              const desired = computeAutoTargetDistance();
+              window.world.autoTargetDistance = desired;
+              window.world.autoReleaseDelay = computeAutoReleaseDelay(desired);
+            } else if (!Number.isFinite(window.world.autoReleaseDelay) || window.world.autoReleaseDelay <= 0) {
+              window.world.autoReleaseDelay = computeAutoReleaseDelay(window.world.autoTargetDistance);
+            }
+          }
+        }
+      } else if (target.holding) {
+        if (!Number.isFinite(window.world.autoTargetDistance)) {
+          window.world.autoTargetDistance = computeAutoTargetDistance();
+        }
+        if (!Number.isFinite(window.world.autoReleaseDelay) || window.world.autoReleaseDelay <= 0) {
+          window.world.autoReleaseDelay = computeAutoReleaseDelay(window.world.autoTargetDistance);
+        }
+        const desiredDistance = window.world.autoTargetDistance ?? TARGET_MAX_DISTANCE - 3;
+        const tolerance = 1.5 + Math.abs(target.velocity || 0) * 0.04;
+        if (
+          target.distance >= desiredDistance - tolerance ||
+          target.reachedTop ||
+          target.holdTime >= window.world.autoReleaseDelay
+        ) {
+          handlePointerUp();
+          window.world.autoHoldActive = false;
+        }
+      } else {
+        window.world.autoHoldActive = false;
+      }
+    } else if (stage !== 'sinking') {
+      window.world.autoHoldActive = false;
+      window.world.autoArmed = false;
+    }
+  }
+
+  function updateEnergyRegen(dt) {
+    const maxEnergy = window.settings.energyMax ?? 10;
+    const interval = window.settings.energyRegenInterval ?? 600;
+    if (!Number.isFinite(interval) || interval <= 0) {
+      window.settings.energyCooldown = 0;
+      return;
+    }
+    if ((window.settings.energy ?? 0) >= maxEnergy) {
+      if (window.settings.energyCooldown !== 0) {
+        window.settings.energyCooldown = 0;
+        window.setHUD();
+      }
+      return;
+    }
+    let cooldown = window.settings.energyCooldown;
+    if (!Number.isFinite(cooldown) || cooldown <= 0) {
+      cooldown = interval;
+    }
+    const previousDisplay = Math.ceil(cooldown) - 1;
+    cooldown = Math.max(0, cooldown - dt);
+    window.settings.energyCooldown = cooldown;
+    if (cooldown <= 0) {
+      window.settings.energy = Math.min(maxEnergy, (window.settings.energy ?? 0) + 1);
+      if (window.settings.energy < maxEnergy) {
+        window.settings.energyCooldown = interval;
+      } else {
+        window.settings.energyCooldown = 0;
+      }
+      window.setHUD();
+      return;
+    }
+    const nextDisplay = Math.ceil(cooldown) - 1;
+    if (nextDisplay !== previousDisplay) {
+      window.setHUD();
+    }
+  }
+
+  function resetReelBattle(hideModals = true) {
+    reelBattle.queue = [];
+    reelBattle.index = -1;
+    reelBattle.results = [];
+    reelBattle.state = null;
+    reelBattle.totalPoints = 0;
+    reelBattle.bonusEnergy = 0;
+    updateBattleCounter();
+    clearNextBattleCountdown();
+    clearSummaryCountdown();
+    window.world.battleQueue = [];
+    window.world.battleResults = [];
+    window.world.currentBattleIndex = -1;
+    window.world.pendingPointTotal = 0;
+    window.world.autoTargetDistance = null;
+    if (hideModals) {
+      setModalVisibility(reelBattle.modal, false);
+      setModalVisibility(reelBattle.summaryModal, false);
+    }
+    if (reelBattle.status) {
+      reelBattle.status.textContent = '';
+      reelBattle.status.classList.remove('success', 'fail');
+    }
+    if (reelBattle.info) {
+      reelBattle.info.textContent = '';
+    }
+    if (reelBattle.fishImage) {
+      reelBattle.fishImage.innerHTML = '';
+      reelBattle.fishImage.classList.remove('celebrate', 'flip');
+      reelBattle.fishImage.style.transform = '';
+    }
+    if (reelBattle.white) {
+      reelBattle.white.style.left = '0%';
+      reelBattle.white.style.width = '100%';
+    }
+    if (reelBattle.marker) {
+      reelBattle.marker.style.left = '50%';
+    }
+    if (reelBattle.nextBtn) {
+      reelBattle.nextBtn.disabled = true;
+      reelBattle.nextBtn.classList.add('disabled');
+    }
+  }
+
+  function ensureEnergyAvailable(showMessage = true) {
+    if ((window.settings.energy ?? 0) > 0) return true;
+    handleOutOfEnergy(showMessage);
+    return false;
+  }
+
+  function handleOutOfEnergy(showMessage = true) {
+    setAutoMode(false, false);
+    cancelAutoCountdown();
+    setModalVisibility(reelBattle.modal, false);
+    setModalVisibility(reelBattle.summaryModal, false);
+    window.state = window.GameState.Idle;
+    window.world.castStage = 'idle';
+    window.world.targetCircle = null;
+    window.world.autoArmed = false;
+    window.world.autoHoldActive = false;
+    window.world.autoCastTimer = 0;
+    window.world.autoReleaseDelay = 0;
+    window.world.autoTargetDistance = null;
+    window.world.bobberVisible = false;
+    window.world.sinkTimer = 0;
+    window.world.sinkDuration = 0;
+    window.world.bobberDist = TARGET_MIN_DISTANCE;
+    window.world.castDistance = TARGET_MIN_DISTANCE;
+    if (window.minimap) window.minimap.style.display = 'none';
+    if (window.distanceEl) window.distanceEl.style.display = 'none';
+    setCastPrompt(false);
+    window.setGameplayLayout(false);
+    resetCharacterToIdle();
+    updateDistanceReadout();
+    if (showMessage) window.toast(ENERGY_WARNING);
+  }
+
+  function consumeEnergyForCast() {
+    if (!ensureEnergyAvailable(true)) return false;
+    const maxEnergy = window.settings.energyMax ?? 10;
+    const regenInterval = window.settings.energyRegenInterval ?? 600;
+    window.settings.energy = Math.max(0, (window.settings.energy ?? 0) - 1);
+    if (window.settings.energy < maxEnergy) {
+      window.settings.energyCooldown = regenInterval;
+    } else {
+      window.settings.energyCooldown = 0;
+    }
+    window.setHUD();
+    return true;
+  }
+
+  function renderBattleFishArt(fish) {
+    if (!reelBattle.fishImage) return;
+    const container = reelBattle.fishImage;
+    container.innerHTML = '';
+    container.classList.remove('celebrate', 'flip');
+    container.style.transform = 'translate(-50%, -50%)';
+    if (!fish) {
+      const placeholder = document.createElement('div');
+      placeholder.className = 'placeholder';
+      container.appendChild(placeholder);
+      return;
+    }
+    if (fish.isTreasure) {
+      const chest = document.createElement('div');
+      chest.className = 'treasure-chest';
+      const sparkle = document.createElement('span');
+      sparkle.className = 'shine';
+      chest.appendChild(sparkle);
+      container.appendChild(chest);
+      return;
+    }
+    const images = fish.spec?.images || {};
+    const cache = window.gameData?.resources?.fish;
+    const cachedImg = fish.image || cache?.get?.(fish.specId) || null;
+    const src = cachedImg?.src || images.card || images.illustration || images.sprite || '';
+    if (src) {
+      const img = document.createElement('img');
+      img.src = src;
+      img.alt = `${fish.spec?.displayName || 'Fish'} illustration`;
+      container.appendChild(img);
+    } else {
+      const placeholder = document.createElement('div');
+      placeholder.className = 'placeholder';
+      container.appendChild(placeholder);
+    }
+  }
+
+  function gatherFishCandidates(range) {
+    const fishes = [];
+    if (!Array.isArray(window.world.fishes)) return fishes;
+    for (const fish of window.world.fishes) {
+      if (!fish || fish.finished) continue;
+      const x = fish.position?.x ?? 0;
+      const y = fish.position?.y ?? fish.distance ?? window.world.bobberDist;
+      const dy = y - window.world.bobberDist;
+      const dist = Math.sqrt(x * x + dy * dy);
+      if (!Number.isFinite(dist)) continue;
+      if (dist <= range) {
+        fishes.push({ fish, dist });
+      }
+    }
+    fishes.sort((a, b) => a.dist - b.dist);
+    return fishes.map(entry => entry.fish);
+  }
+
+  function createTreasureCandidate() {
+    const rewardType = Math.random() < 0.65 ? 'points' : 'energy';
+    const pointsAmount = Math.round(window.rand(140, 280));
+    const energyAmount = Math.random() < 0.4 ? 2 : 1;
+    const fish = {
+      isTreasure: true,
+      spec: {
+        displayName: '보물 상자',
+        rarity: rewardType === 'points' ? '희귀' : '에너지',
+        images: {}
+      },
+      size_cm: 0,
+      weight_kg: 0,
+      rewardType,
+      rewardAmount: rewardType === 'points' ? pointsAmount : energyAmount
+    };
+
+    return {
+      type: 'treasure',
+      fish,
+      chance: 1,
+      success: true,
+      resolved: false,
+      points: rewardType === 'points' ? pointsAmount : 0,
+      treasure: {
+        type: rewardType,
+        amount: rewardType === 'points' ? pointsAmount : energyAmount
+      }
+    };
+  }
+
+  function computeBattleChance(fish, candidateCount) {
+    const spec = fish?.spec || {};
+    let base = 0.55;
+    const rarityAdjust = {
+      Common: 0.12,
+      Uncommon: 0.05,
+      Rare: -0.02,
+      Epic: -0.08,
+      Legendary: -0.15,
+      Mythic: -0.2
+    }[spec.rarity] ?? 0;
+    base += rarityAdjust;
+    const stressFactor = window.clamp(1 - (fish?.stressLevel ?? 0) * 0.35, 0.7, 1.1);
+    base *= stressFactor;
+    const crowding = window.clamp(0.12 - (candidateCount - 1) * 0.04, -0.12, 0.18);
+    base += crowding;
+    if (fish?.bonusMultiplier > 1) {
+      base += 0.04 * (fish.bonusMultiplier - 1);
+    }
+    return window.clamp(base, 0.1, 0.92);
+  }
+
+  function startReelBattleSequence(fishes) {
+    if (!Array.isArray(fishes) || !fishes.length) return;
+    window.state = window.GameState.Results;
+    window.world.castStage = 'idle';
+    window.world.bobberVisible = false;
+    resetReelBattle(false);
+    reelBattle.queue = fishes.map(fish => {
+      const chance = computeBattleChance(fish, fishes.length);
+      return {
+        fish,
+        chance,
+        success: Math.random() < chance,
+        resolved: false,
+        points: 0
+      };
+    });
+    if (Math.random() < 0.05) {
+      const treasure = createTreasureCandidate();
+      const insertIndex = Math.min(
+        reelBattle.queue.length,
+        Math.floor(Math.random() * (reelBattle.queue.length + 1))
+      );
+      reelBattle.queue.splice(insertIndex, 0, treasure);
+    }
+    reelBattle.index = -1;
+    reelBattle.results = [];
+    reelBattle.totalPoints = 0;
+    reelBattle.state = null;
+    window.world.battleQueue = reelBattle.queue.map(entry => entry.fish);
+    window.world.battleResults = reelBattle.results;
+    window.world.currentBattleIndex = -1;
+    window.world.pendingPointTotal = 0;
+    if (window.results) window.results.style.display = 'none';
+    if (window.minimap) window.minimap.style.display = 'none';
+    if (window.distanceEl) window.distanceEl.style.display = 'none';
+    setCastPrompt(false);
+    beginNextReelBattle();
+  }
+
+  function beginNextReelBattle() {
+    clearNextBattleCountdown();
+    reelBattle.index += 1;
+    window.world.currentBattleIndex = reelBattle.index;
+    if (reelBattle.index >= reelBattle.queue.length) {
+      finishReelBattleSequence();
+      return;
+    }
+    setupReelBattle(reelBattle.queue[reelBattle.index]);
+  }
+
+  function setupReelBattle(candidate) {
+    if (!candidate || !candidate.fish) {
+      beginNextReelBattle();
+      return;
+    }
+    updateBattleCounter();
+    const fish = candidate.fish;
+    const baseStatus = candidate.type === 'treasure' ? '보물 상자를 끌어올리는 중...' : '줄을 잡아당기는 중...';
+    if (reelBattle.status) {
+      reelBattle.status.textContent = baseStatus;
+      reelBattle.status.classList.remove('success', 'fail');
+    }
+    if (reelBattle.info) {
+      if (fish.isTreasure) {
+        reelBattle.info.textContent = '무언가 묵직한 것이 걸렸어요!';
+      } else {
+        const name = fish.spec?.displayName || '알 수 없는 물고기';
+        reelBattle.info.textContent = `${name}이(가) 버티고 있습니다.`;
+      }
+    }
+    renderBattleFishArt(fish);
+    if (reelBattle.white) {
+      reelBattle.white.style.left = '0%';
+      reelBattle.white.style.width = '100%';
+    }
+    if (reelBattle.marker) {
+      reelBattle.marker.style.left = '50%';
+    }
+    if (reelBattle.nextBtn) {
+      reelBattle.nextBtn.disabled = true;
+      reelBattle.nextBtn.classList.add('disabled');
+      reelBattle.nextBtn.textContent = 'Next';
+    }
+    clearNextBattleCountdown();
+    setModalVisibility(reelBattle.modal, true);
+    reelBattle.state = {
+      candidate,
+      elapsed: 0,
+      duration: reelBattle.duration,
+      redWidth: reelBattle.redWidth,
+      finalWhite: reelBattle.finalWhite,
+      currentWidth: 1,
+      fishPos: 0.5,
+      fishDirection: -1,
+      fishPhase: Math.random() * Math.PI * 2,
+      fishSpeed: 4.2 + Math.random() * 2.2,
+      success: candidate.success,
+      resolved: false,
+      failTriggered: false,
+      failDirection: Math.random() > 0.5 ? 1 : -1,
+      statusBase: baseStatus,
+      statusTimer: 0,
+      tensionTimer: fish.isTreasure ? window.rand(0.7, 1.2) : window.rand(0.45, 0.9),
+      tensionDuration: 0,
+      tensionElapsed: 0,
+      tensionStrength: fish.isTreasure ? 0.4 : 0.7,
+      tensionDirection: Math.random() > 0.5 ? 1 : -1,
+      tensionOffset: 0,
+      whitePulse: 0,
+      playerSurgeDelay: 0,
+      playerSurgeTimer: 0,
+      playerSurgeDuration: 0,
+      playerSurgeStrength: 0
+    };
+  }
+
+  function resolveReelBattleOutcome(success) {
+    const state = reelBattle.state;
+    if (!state || state.resolved) return;
+    state.resolved = true;
+    const candidate = state.candidate;
+    candidate.resolved = true;
+    candidate.outcome = success;
+    const fish = candidate.fish;
+    const name = fish.spec?.displayName || 'Mystery Fish';
+    const rarity = fish.spec?.rarity || 'Unknown';
+    const isTreasure = !!fish.isTreasure || candidate.type === 'treasure';
+    if (!isTreasure) fish.finished = true;
+    if (reelBattle.status) {
+      const statusText = success ? (isTreasure ? '보물 발견!' : '성공') : '실패';
+      reelBattle.status.textContent = statusText;
+      reelBattle.status.classList.toggle('success', success);
+      reelBattle.status.classList.toggle('fail', !success);
+    }
+    let infoHtml = '';
+    if (success) {
+      if (reelBattle.fishImage) reelBattle.fishImage.classList.add('celebrate');
+      if (isTreasure) {
+        const reward = candidate.treasure || {
+          type: fish.rewardType || 'points',
+          amount: fish.rewardAmount || 0
+        };
+        if (reward.type === 'points') {
+          const points = Math.max(0, Math.round(reward.amount));
+          candidate.points = points;
+          reelBattle.totalPoints += points;
+          window.world.pendingPointTotal = reelBattle.totalPoints;
+          reelBattle.results.push({ type: 'treasure', fish, success: true, treasure: reward, points });
+          infoHtml = `
+            <p><strong>보물 상자</strong></p>
+            <p>빛나는 보석이 가득합니다.</p>
+            <p><strong>Points +${points}</strong></p>
+          `;
+        } else {
+          const gain = Math.max(1, Math.round(reward.amount));
+          candidate.points = 0;
+          reelBattle.bonusEnergy += gain;
+          reelBattle.results.push({ type: 'treasure', fish, success: true, treasure: reward, points: 0 });
+          infoHtml = `
+            <p><strong>보물 상자</strong></p>
+            <p>에너지 포션을 발견했습니다.</p>
+            <p><strong>Energy +${gain}</strong></p>
+          `;
+        }
+      } else {
+        const points = computePoints(fish, window.world.castDistance);
+        candidate.points = points;
+        reelBattle.totalPoints += points;
+        window.world.pendingPointTotal = reelBattle.totalPoints;
+        reelBattle.results.push({ fish, success: true, points });
+        if (!window.world.catches.includes(fish)) {
+          window.world.catches.push(fish);
+        }
+        infoHtml = `
+          <p><strong>${escapeHtml(name)}</strong> (${escapeHtml(rarity)})</p>
+          <p>Size: ${fish.size_cm.toFixed(1)} cm · Weight: ${fish.weight_kg.toFixed(2)} kg</p>
+          <p><strong>Points +${points}</strong></p>
+        `;
+      }
+    } else {
+      candidate.points = 0;
+      if (isTreasure) {
+        infoHtml = `
+          <p><strong>보물 상자</strong></p>
+          <p>줄에서 빠져버렸어요...</p>
+        `;
+        reelBattle.results.push({ type: 'treasure', fish, success: false, treasure: candidate.treasure || null, points: 0 });
+      } else {
+        reelBattle.results.push({ fish, success: false, points: 0 });
+        infoHtml = `
+          <p><strong>${escapeHtml(name)}</strong> (${escapeHtml(rarity)})</p>
+          <p>Size: ${fish.size_cm.toFixed(1)} cm · Weight: ${fish.weight_kg.toFixed(2)} kg</p>
+          <p><strong>Points +0</strong></p>
+          <p style="margin-top:6px;">도망가 버렸어요!</p>
+        `;
+      }
+    }
+    if (reelBattle.info) {
+      reelBattle.info.innerHTML = infoHtml;
+    }
+    if (reelBattle.nextBtn) {
+      reelBattle.nextBtn.disabled = false;
+      reelBattle.nextBtn.classList.remove('disabled');
+    }
+    const hasMore = reelBattle.index < reelBattle.queue.length - 1;
+    if (reelBattle.nextBtn) {
+      reelBattle.nextBtn.textContent = hasMore ? 'Next' : 'Summary';
+    }
+    if (hasMore) {
+      startNextBattleCountdown('next');
+    } else {
+      startNextBattleCountdown('summary');
+    }
+  }
+
+  function updateReelBattle(dt) {
+    const summaryVisible = reelBattle.summaryModal?.style.display === 'flex';
+    if (reelBattle.summaryCountdownActive) {
+      reelBattle.summaryCountdownTimer = Math.max(0, reelBattle.summaryCountdownTimer - dt);
+      if (reelBattle.summaryCountdownLabel) {
+        const seconds = Math.max(0, reelBattle.summaryCountdownTimer);
+        reelBattle.summaryCountdownLabel.textContent = `Close ${seconds.toFixed(1)}s`;
+      }
+      if (reelBattle.summaryCountdownTimer <= 0 && summaryVisible) {
+        reelBattle.summaryCountdownActive = false;
+        closeCatchSummary();
+        return;
+      }
+    }
+
+    const state = reelBattle.state;
+    if (!state || !reelBattle.modal || summaryVisible) return;
+    if (!state.resolved && state.statusTimer > 0) {
+      state.statusTimer = Math.max(0, state.statusTimer - dt);
+      if (state.statusTimer <= 0 && reelBattle.status) {
+        reelBattle.status.textContent = state.statusBase;
+      }
+    }
+    const candidate = state.candidate || null;
+    const fish = candidate?.fish || null;
+    const isTreasure = !!fish?.isTreasure;
+    const previousPos = state.fishPos;
+    state.elapsed = Math.min(state.elapsed + dt, state.duration + 0.6);
+    const t = window.clamp(state.elapsed / state.duration, 0, 1);
+    const eased = t * t * (3 - 2 * t);
+    state.whitePulse = Math.max(0, (state.whitePulse || 0) - dt * 0.85);
+    const baseWidth = window.lerp(1, state.finalWhite, eased);
+    const currentWidth = window.clamp(baseWidth + (state.whitePulse || 0), state.finalWhite, 1);
+    state.currentWidth = currentWidth;
+    const whiteLeft = 0.5 - currentWidth / 2;
+    if (reelBattle.white) {
+      reelBattle.white.style.left = `${whiteLeft * 100}%`;
+      reelBattle.white.style.width = `${currentWidth * 100}%`;
+    }
+    state.fishPhase += dt * state.fishSpeed;
+    const safeAmplitude = Math.max(0.02, currentWidth / 2 - state.redWidth / 2 - 0.01);
+    if (!state.resolved) {
+      if (!Number.isFinite(state.tensionOffset)) state.tensionOffset = 0;
+      if (state.tensionDuration > 0) {
+        state.tensionElapsed += dt;
+        const progress = Math.min(1, state.tensionElapsed / state.tensionDuration);
+        const swing = Math.sin(progress * Math.PI);
+        const bias = state.success ? 0.8 : 1.15;
+        state.tensionOffset = state.tensionDirection * state.tensionStrength * swing * bias;
+        if (state.tensionElapsed >= state.tensionDuration) {
+          state.tensionDuration = 0;
+          state.tensionElapsed = 0;
+          state.tensionTimer = isTreasure ? window.rand(0.9, 1.4) : window.rand(0.45, 0.85);
+        }
+      } else {
+        state.tensionOffset *= Math.pow(0.2, dt);
+        state.tensionTimer -= dt;
+        if (state.tensionTimer <= 0) {
+          state.tensionDuration = isTreasure ? window.rand(0.5, 0.9) : window.rand(0.35, 0.75);
+          state.tensionElapsed = 0;
+          const outward = Math.sign((state.fishPos ?? 0.5) - 0.5) || (Math.random() > 0.5 ? 1 : -1);
+          const baseDir = Math.random() < 0.5 ? -1 : 1;
+          state.tensionDirection = Math.random() < 0.55 ? baseDir : outward;
+          state.tensionStrength = isTreasure ? window.rand(0.2, 0.45) : window.rand(0.45, 0.8);
+          const pool = isTreasure ? TREASURE_MESSAGES : FISH_TUG_MESSAGES;
+          setBattleStatusMessage(state, pickMessage(pool), 0.9);
+          if (state.success) {
+            state.playerSurgeDelay = window.rand(0.15, 0.3);
+            state.playerSurgeDuration = window.rand(0.35, 0.55);
+            state.playerSurgeStrength = window.rand(1.1, 1.8);
+          } else if (Math.random() < 0.45) {
+            state.playerSurgeDelay = window.rand(0.25, 0.45);
+            state.playerSurgeDuration = window.rand(0.25, 0.4);
+            state.playerSurgeStrength = window.rand(0.6, 1.0);
+          }
+        }
+      }
+
+      if (state.playerSurgeDelay > 0) {
+        state.playerSurgeDelay -= dt;
+        if (state.playerSurgeDelay <= 0 && state.playerSurgeDuration > 0) {
+          setBattleStatusMessage(state, pickMessage(PLAYER_TUG_MESSAGES), 0.8);
+          state.playerSurgeTimer = state.playerSurgeDuration;
+        }
+      } else if (state.playerSurgeTimer > 0) {
+        state.playerSurgeTimer = Math.max(0, state.playerSurgeTimer - dt);
+      }
+    }
+
+    const amplitude = state.success ? Math.max(0.02, safeAmplitude) : Math.max(0.02, safeAmplitude * 0.9);
+    let desired = 0.5 + Math.sin(state.fishPhase) * amplitude;
+    desired += state.tensionOffset || 0;
+    state.fishPos += (desired - state.fishPos) * (1 - Math.pow(0.001, dt * 16));
+
+    if (state.playerSurgeTimer > 0 && state.playerSurgeDuration > 0) {
+      const progress = 1 - state.playerSurgeTimer / Math.max(state.playerSurgeDuration, 0.0001);
+      const curve = Math.sin(Math.min(1, progress) * Math.PI);
+      const pullStrength = state.playerSurgeStrength * curve * (state.success ? 1.25 : 0.7);
+      const pull = (0.5 - state.fishPos) * pullStrength * dt * 1.6;
+      state.fishPos += pull;
+      state.whitePulse = Math.max(state.whitePulse || 0, Math.abs(pullStrength) * 0.05);
+    }
+
+    if (!state.success) {
+      if (!state.failTriggered && state.elapsed > state.duration * 0.45) {
+        state.failTriggered = true;
+        if (!state.failDirection) {
+          state.failDirection = Math.sign(state.tensionOffset || (Math.random() - 0.5)) || 1;
+        }
+      }
+      if (state.failTriggered) {
+        state.fishPos += state.failDirection * dt * 0.55;
+      }
+    }
+
+    if (state.success) {
+      state.fishPos = window.clamp(state.fishPos, whiteLeft + 0.02, whiteLeft + currentWidth - 0.02);
+    } else {
+      state.fishPos = window.clamp(state.fishPos, 0, 1);
+    }
+    const delta = state.fishPos - previousPos;
+    if (Math.abs(delta) > 0.0005) {
+      state.fishDirection = delta > 0 ? 1 : -1;
+    }
+    const facingRight = state.fishDirection > 0;
+    const trackWidth = reelBattle.white?.parentElement?.clientWidth || 0;
+    if (reelBattle.marker) {
+      reelBattle.marker.style.left = `${state.fishPos * 100}%`;
+    }
+    if (reelBattle.fishImage && trackWidth) {
+      const offset = (state.fishPos - 0.5) * trackWidth;
+      reelBattle.fishImage.style.transform = `translate(-50%, -50%) translateX(${offset}px)`;
+      if (isTreasure) {
+        reelBattle.fishImage.classList.remove('flip');
+      } else {
+        reelBattle.fishImage.classList.toggle('flip', facingRight);
+      }
+    } else if (reelBattle.fishImage) {
+      if (isTreasure) {
+        reelBattle.fishImage.classList.remove('flip');
+      } else {
+        reelBattle.fishImage.classList.toggle('flip', facingRight);
+      }
+    }
+    const whiteRight = whiteLeft + currentWidth;
+    const redLeft = 0.5 - state.redWidth / 2;
+    const redRight = 0.5 + state.redWidth / 2;
+    if (!state.resolved) {
+      if (state.success && currentWidth <= state.redWidth + 0.001) {
+        if (state.fishPos >= redLeft && state.fishPos <= redRight) {
+          resolveReelBattleOutcome(true);
+        }
+      }
+      if (!state.success && (state.fishPos < whiteLeft || state.fishPos > whiteRight)) {
+        resolveReelBattleOutcome(false);
+      }
+      if (state.elapsed >= state.duration + 0.5 && !state.resolved) {
+        resolveReelBattleOutcome(state.success);
+      }
+    }
+    if (reelBattle.autoAdvanceActive) {
+      reelBattle.autoAdvanceTimer = Math.max(0, reelBattle.autoAdvanceTimer - dt);
+      if (reelBattle.nextCountdownLabel) {
+        const seconds = Math.max(0, reelBattle.autoAdvanceTimer);
+        const prefix = reelBattle.autoAdvanceMode === 'summary' ? 'Summary' : 'Next';
+        reelBattle.nextCountdownLabel.textContent = `${prefix} ${seconds.toFixed(1)}s`;
+      }
+      if (reelBattle.autoAdvanceTimer <= 0) {
+        clearNextBattleCountdown();
+        if (reelBattle.state && reelBattle.state.resolved) {
+          reelBattle.state = null;
+        }
+        beginNextReelBattle();
+        return;
+      }
+    }
+  }
+
+  function finishReelBattleSequence() {
+    reelBattle.state = null;
+    setModalVisibility(reelBattle.modal, false);
+    showCatchSummary();
+  }
+
+  function showCatchSummary() {
+    if (!reelBattle.summaryModal) {
+      preparePlayRound(true);
+      return;
+    }
+    const list = reelBattle.summaryList;
+    if (list) {
+      if (!reelBattle.results.length) {
+        list.innerHTML = '<p>아무 것도 잡지 못했습니다.</p>';
+      } else {
+        list.innerHTML = reelBattle.results
+          .map((result, index) => {
+            if (result.type === 'treasure') {
+              const reward = result.treasure || { type: 'points', amount: result.points };
+              const status = result.success ? '발견' : '실패';
+              const tail = result.success
+                ? reward.type === 'points'
+                  ? `+${Math.max(0, Math.round(reward.amount))}`
+                  : `Energy +${Math.max(1, Math.round(reward.amount || 1))}`
+                : '+0';
+              return `<p><span>${index + 1}. 보물 상자 – ${status}</span><span>${tail}</span></p>`;
+            }
+            const fish = result.fish;
+            const name = escapeHtml(fish.spec?.displayName || `Catch ${index + 1}`);
+            const rarity = escapeHtml(fish.spec?.rarity || 'Unknown');
+            const points = result.points;
+            const label = result.success ? `+${points}` : '+0';
+            const status = result.success ? '성공' : '실패';
+            return `<p><span>${index + 1}. ${name} (${rarity}) – ${status}</span><span>${label}</span></p>`;
+          })
+          .join('');
+        if (reelBattle.bonusEnergy > 0) {
+          list.innerHTML += `<p class="summary-energy">추가 보상 – Energy +${reelBattle.bonusEnergy}</p>`;
+        }
+      }
+    }
+    if (reelBattle.summaryTotal) {
+      reelBattle.summaryTotal.textContent = reelBattle.totalPoints.toLocaleString();
+    }
+    setModalVisibility(reelBattle.summaryModal, true);
+    startSummaryCountdown();
+  }
+
+  function closeCatchSummary() {
+    clearSummaryCountdown();
+    const total = reelBattle.totalPoints;
+    const bonusEnergy = reelBattle.bonusEnergy;
+    setModalVisibility(reelBattle.summaryModal, false);
+    if (total > 0) {
+      window.addPointsWithSparkle(total);
+    } else if (bonusEnergy === 0) {
+      window.setHUD();
+    }
+    if (bonusEnergy > 0) {
+      window.addEnergy(bonusEnergy, { toast: `Energy +${bonusEnergy}` });
+    }
+    resetReelBattle();
+    if (ensureEnergyAvailable()) {
+      preparePlayRound(true);
+    }
+  }
+
   function resetTargetCircle() {
     window.world.targetCircle = {
       distance: TARGET_MIN_DISTANCE,
@@ -313,7 +1529,6 @@
     window.world.sinkDuration = 0;
     window.world.sinkStartDist = TARGET_MIN_DISTANCE;
     window.world.sinkEndDist = TARGET_MIN_DISTANCE;
-    window.world.pendingCatchSims = [];
     if (window.waveEffect) {
       window.waveEffect.playing = false;
       window.waveEffect.frameIndex = 0;
@@ -334,16 +1549,22 @@
   }
 
   function preparePlayRound(respawn = true) {
+    if (!ensureEnergyAvailable()) return;
     window.state = window.GameState.Targeting;
     window.camera.y = 0;
     window.world.actives = [];
     window.world.catches = [];
-    window.world.pendingCatchSims = [];
     window.resultsIndex = 0;
     window.world.time = 0;
     window.world.targetZoom = 1;
     window.world.viewZoom = 1;
     window.world.bobberVisible = false;
+    resetReelBattle();
+    window.world.autoTargetDistance = null;
+    window.world.autoCastTimer = 0;
+    window.world.autoHoldActive = false;
+    window.world.autoReleaseDelay = 0;
+    window.world.autoArmed = false;
     if (window.waveEffect) {
       window.waveEffect.playing = false;
       window.waveEffect.frameIndex = 0;
@@ -372,19 +1593,23 @@
       }
     }
     resetTargetCircle();
-    clearCatchSimulations();
     updateDistanceReadout();
     if (window.minimap) window.minimap.style.display = 'flex';
     if (window.distanceEl) window.distanceEl.style.display = 'block';
     setCastPrompt(true, 'Press the Screen to cast the bobber');
     resetCharacterToIdle();
+    if (window.world.autoMode) {
+      scheduleAutoCast(window.rand(0.3, 0.6));
+    }
   }
 
   function exitToMenu() {
+    setAutoMode(false, false);
     window.state = window.GameState.Idle;
     window.camera.y = 0;
     setCastPrompt(false);
     awardRemainingCatchPoints();
+    resetReelBattle();
     window.world.targetCircle = null;
     window.world.actives = [];
     window.world.catches = [];
@@ -399,8 +1624,6 @@
     window.world.sinkDuration = 0;
     window.world.sinkStartDist = TARGET_MIN_DISTANCE;
     window.world.sinkEndDist = TARGET_MIN_DISTANCE;
-    window.world.pendingCatchSims = [];
-    clearCatchSimulations();
     window.resultsIndex = 0;
     if (window.results) window.results.style.display = 'none';
     if (window.minimap) window.minimap.style.display = 'none';
@@ -416,9 +1639,9 @@
   }
 
   function startPlaySession() {
+    if (!ensureEnergyAvailable()) return;
+    closeShop();
     window.setGameplayLayout(true);
-    window.settings.energy = Math.max(0, window.settings.energy - 1);
-    window.setHUD();
     preparePlayRound(true);
   }
 
@@ -446,7 +1669,8 @@
     updateDistanceReadout();
   }
 
-  function handlePointerDown() {
+  function handlePointerDown(event) {
+    if (event?.target?.closest?.('#autoBtn')) return;
     if (window.state !== window.GameState.Targeting) return;
     if (window.world.castStage !== 'aiming') return;
     const target = window.world.targetCircle;
@@ -457,10 +1681,6 @@
     target.reachedTop = false;
     setCastPrompt(false);
     startCharacterCastAnimation();
-  }
-
-  function clearCatchSimulations() {
-    window.world.pendingCatchSims = [];
   }
 
   function triggerBobberImpact(distance) {
@@ -532,6 +1752,13 @@
     if (window.world.castStage !== 'aiming') return;
     const target = window.world.targetCircle;
     if (!target) return;
+    if (!consumeEnergyForCast()) {
+      target.holding = false;
+      target.velocity = 0;
+      target.holdTime = 0;
+      window.world.targetZoom = 1;
+      return;
+    }
     window.world.castStage = 'sinking';
     window.world.bobberVisible = true;
     window.world.sinkTimer = 0;
@@ -543,50 +1770,9 @@
     window.world.castDistance = target.distance;
     scatterFishesAroundTarget(target.distance);
     triggerBobberImpact(target.distance);
-    clearCatchSimulations();
     window.world.targetCircle = null;
     setCastPrompt(true, 'Pull!');
     updateDistanceReadout();
-  }
-
-  function updateCatchSimulations(dt) {
-    if (!Array.isArray(window.world.pendingCatchSims)) {
-      window.world.pendingCatchSims = [];
-    }
-    const sims = window.world.pendingCatchSims;
-    const actives = Array.isArray(window.world.actives) ? window.world.actives : [];
-
-    for (const active of actives) {
-      if (!active || !active.fish) continue;
-      let sim = sims.find(entry => entry.fish === active.fish);
-      if (!sim) {
-        sim = {
-          fish: active.fish,
-          active,
-          successes: 0,
-          failures: 0,
-          timer: window.rand(0, 0.2),
-          interval: window.rand(0.25, 0.55),
-          lastOutcome: null
-        };
-        sims.push(sim);
-      }
-      sim.active = active;
-      sim.timer += dt;
-      while (sim.timer >= sim.interval) {
-        sim.timer -= sim.interval;
-        const success = rollCatch(active);
-        if (success) {
-          sim.successes += 1;
-        } else {
-          sim.failures += 1;
-        }
-        sim.lastOutcome = success;
-        sim.interval = window.rand(0.25, 0.55);
-      }
-    }
-
-    window.world.pendingCatchSims = sims.filter(sim => actives.includes(sim.active));
   }
 
   function updateSinkPhase(dt) {
@@ -598,7 +1784,6 @@
     const nextDist = window.lerp(window.world.sinkStartDist, window.world.sinkEndDist, eased);
     window.world.bobberDist = window.clamp(nextDist, SINK_MIN_DISTANCE, TARGET_MAX_DISTANCE);
     updateDistanceReadout();
-    updateCatchSimulations(dt);
     if (window.world.sinkTimer >= duration) {
       finalizeCatchAttempt();
     }
@@ -626,56 +1811,37 @@
     window.world.castStage = 'resolved';
     setCastPrompt(false);
     const actives = Array.isArray(window.world.actives) ? window.world.actives.slice() : [];
-    const sims = Array.isArray(window.world.pendingCatchSims) ? window.world.pendingCatchSims : [];
-    const caughtNow = [];
     let anyActive = false;
-
     for (const active of actives) {
       if (!active || !active.fish) continue;
       anyActive = true;
-      const fish = active.fish;
-      const sim = sims.find(entry => entry.fish === fish) || null;
-      let success = false;
-      if (sim) {
-        const totalChecks = sim.successes + sim.failures;
-        if (totalChecks === 0) {
-          success = rollCatch(active);
-        } else if (sim.successes === sim.failures) {
-          success = sim.lastOutcome ?? rollCatch(active);
-        } else {
-          success = sim.successes > sim.failures;
-        }
-      } else {
-        success = rollCatch(active);
-      }
-
-      if (success) {
-        fish.finished = true;
-        fish.engaged = false;
-        if (fish.active) fish.active = null;
-        caughtNow.push(fish);
-        window.world.catches.push(fish);
-      }
       releaseActiveCircle(active, false);
     }
-
     window.world.actives = [];
-    clearCatchSimulations();
     window.world.bobberVisible = false;
 
-    if (caughtNow.length) {
-      showResults();
+    const detectionRange = window.DETECTION_RANGE_M ?? 5;
+    const candidates = gatherFishCandidates(detectionRange);
+    if (!candidates.length) {
+      window.showMissEffect();
+      if (!anyActive) {
+        window.toast('Miss – no fish bit the bobber.');
+      }
+      preparePlayRound(true);
       return;
     }
 
-    window.showMissEffect();
-    if (!anyActive) {
-      window.toast('Miss – no fish bit the bobber.');
+    for (const fish of candidates) {
+      if (!fish) continue;
+      fish.engaged = false;
+      if (fish.active) fish.active = null;
     }
-    preparePlayRound(true);
+    window.world.catches = [];
+    startReelBattleSequence(candidates);
   }
 
-  function handlePointerUp() {
+  function handlePointerUp(event) {
+    if (event?.target?.closest?.('#autoBtn')) return;
     if (window.state !== window.GameState.Targeting) return;
     if (window.world.castStage !== 'aiming') return;
     const target = window.world.targetCircle;
@@ -710,8 +1876,6 @@
 
     const fish = window.world.catches[window.resultsIndex];
     const points = computePoints(fish, window.world.castDistance);
-    window.settings.points += points;
-    window.setHUD();
 
     window.rTitle.textContent = `Catch ${window.resultsIndex + 1}/${count}`;
     const escapeHtml = value => String(value ?? '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
@@ -743,18 +1907,7 @@
   }
 
   function awardRemainingCatchPoints() {
-    if (!Array.isArray(window.world.catches) || !window.world.catches.length) return;
-    let bonus = 0;
-    for (let i = window.resultsIndex + 1; i < window.world.catches.length; i++) {
-      const fish = window.world.catches[i];
-      if (!fish) continue;
-      const points = computePoints(fish, window.world.castDistance);
-      window.settings.points += points;
-      bonus += points;
-    }
-    if (bonus > 0) {
-      window.setHUD();
-    }
+    return;
   }
 
   function closeResultsToContinue() {
@@ -1084,6 +2237,10 @@
     updateCharacterAnimation(dt);
     updateFishSimulation(dt);
     updateBobberWave(dt);
+    updateReelBattle(dt);
+    updateAutoCountdown(dt);
+    updateAutoPlay(dt);
+    updateEnergyRegen(dt);
 
     const metrics = getEnvironmentMetrics(window.canvas.width, window.canvas.height);
     if (window.state === window.GameState.Targeting) {
@@ -1127,7 +2284,7 @@
       }
       if (window.state !== window.GameState.Idle) return;
       if (window.settings.energy <= 0) {
-        window.toast('Not enough energy.');
+        window.toast(ENERGY_WARNING);
         return;
       }
       startPlaySession();
@@ -1136,7 +2293,7 @@
     window.canvas.addEventListener('click', () => {
       if (window.state === window.GameState.Idle && window.dataLoaded && window.assetsReady) {
         if (window.settings.energy <= 0) {
-          window.toast('Not enough energy.');
+          window.toast(ENERGY_WARNING);
           return;
         }
         startPlaySession();
@@ -1160,13 +2317,80 @@
       closeResultsToContinue();
     });
 
+    if (reelBattle.nextBtn) {
+      reelBattle.nextBtn.addEventListener('click', () => {
+        if (!reelBattle.state || !reelBattle.state.resolved) return;
+        clearNextBattleCountdown();
+        reelBattle.state = null;
+        beginNextReelBattle();
+      });
+    }
+
+    if (reelBattle.summaryClose) {
+      reelBattle.summaryClose.addEventListener('click', () => {
+        closeCatchSummary();
+      });
+    }
+
     const comingSoon = label => () => window.toast(`${label} – Coming Soon`);
-    if (window.shopBtn) window.shopBtn.addEventListener('click', comingSoon('Shop'));
+    if (window.shopBtn) {
+      window.shopBtn.addEventListener('click', () => {
+        if (window.state !== window.GameState.Idle) return;
+        openShop();
+      });
+    }
     if (window.rankBtn) window.rankBtn.addEventListener('click', comingSoon('Ranking'));
     if (window.premiumBtn) window.premiumBtn.addEventListener('click', comingSoon('Premium Mode'));
+    if (shopUI.closeBtn) {
+      shopUI.closeBtn.addEventListener('click', () => closeShop());
+    }
+    if (shopUI.modal) {
+      shopUI.modal.addEventListener('click', event => {
+        if (event.target === shopUI.modal) closeShop();
+      });
+    }
+    document.addEventListener('keydown', event => {
+      if (event.key === 'Escape' && shopUI.modal?.getAttribute('aria-hidden') === 'false') {
+        closeShop();
+      }
+    });
     if (window.exitBtn) {
       window.exitBtn.addEventListener('click', () => {
         exitToMenu();
+      });
+    }
+
+    if (window.autoBtn) {
+      window.autoBtn.addEventListener('click', () => {
+        if (!window.dataLoaded || !window.assetsReady) {
+          window.toast('Load the data first.');
+          return;
+        }
+        if (window.world.autoCountdownActive) {
+          cancelAutoCountdown();
+          window.toast('Auto 시작을 취소했습니다.');
+          return;
+        }
+        if (!window.world.autoMode) {
+          if (window.settings.energy <= 0) {
+            window.toast(ENERGY_WARNING);
+            return;
+          }
+          const triggerAutoStart = () => {
+            if (!ensureEnergyAvailable()) return;
+            setAutoMode(true, true);
+            if (window.state === window.GameState.Idle) {
+              startPlaySession();
+            } else if (window.state === window.GameState.Targeting) {
+              scheduleAutoCast(window.rand(0.3, 0.6));
+            }
+            window.toast('Auto 모드를 시작했습니다.');
+          };
+          showAutoCountdown(2, triggerAutoStart);
+        } else {
+          setAutoMode(false, false);
+          window.toast('Auto 모드를 종료했습니다.');
+        }
       });
     }
   }
@@ -1189,12 +2413,6 @@
 
     setupEventListeners();
     requestAnimationFrame(gameLoop);
-    setInterval(() => {
-      if (window.settings.energy < 10) {
-        window.settings.energy++;
-        window.setHUD();
-      }
-    }, 30000);
   }
 
   document.addEventListener('DOMContentLoaded', () => {

--- a/js/state.js
+++ b/js/state.js
@@ -92,12 +92,19 @@ window.mainMenu = null;
 window.titleBar = null;
 window.navBar = null;
 window.exitBtn = null;
+window.autoBtn = null;
 window.shopBtn = null;
+window.shopModal = null;
+window.shopCloseBtn = null;
+window.shopProducts = null;
+window.shopPointsEl = null;
 window.rankBtn = null;
 window.premiumBtn = null;
 window.toastEl = null;
 window.missEffect = null;
 window.distanceEl = null;
+window.autoCountdownEl = null;
+window.autoCountdownTimerEl = null;
 window.minimap = null;
 window.mmbar = null;
 window.mmCells = null;
@@ -129,7 +136,10 @@ window.CHARACTERS = window.gameData.characters;
 
 window.settings = {
   energy: 10,
-  points: 0,
+  energyMax: 10,
+  energyRegenInterval: 600,
+  energyCooldown: 0,
+  points: 3000,
   baseCast: 30,
   maxCast: 200,
   rodTier: 1,
@@ -154,7 +164,19 @@ window.world = {
   sinkDuration: 0,
   sinkStartDist: 0,
   sinkEndDist: 0,
-  pendingCatchSims: []
+  battleQueue: [],
+  battleResults: [],
+  currentBattleIndex: -1,
+  pendingPointTotal: 0,
+  autoMode: false,
+  autoHoldActive: false,
+  autoCastTimer: 0,
+  autoReleaseDelay: 0,
+  autoTargetDistance: null,
+  autoArmed: false,
+  autoCountdownActive: false,
+  autoCountdownTimer: 0,
+  autoCountdownCallback: null
 };
 
 window.camera = { y: 0 };


### PR DESCRIPTION
## Summary
- add a modal shop with energy bundles, updated HUD styling, and 3000 starting points so players can spend and track points from the main menu
- show an Auto Play Start countdown overlay and start automation after two seconds, including cancel handling and button feedback
- share HUD helpers for spending points or granting energy so summary rewards and purchases stay in sync

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d634410758832aa8839a923c9b4fe4